### PR TITLE
Add Vitest setup and App smoke test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -22,6 +23,10 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^1.6.0",
+    "jsdom": "^26.0.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.0.0"
   }
 }

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,0 +1,10 @@
+import { render } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import App from '../App'
+
+describe('App', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<App />)
+    expect(container).toBeTruthy()
+  })
+})

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
 })


### PR DESCRIPTION
## Summary
- add Vitest and React Testing Library dev dependencies
- configure Vite's test environment for jsdom
- add basic test ensuring `<App />` renders without crashing

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@testing-library%2fjest-dom)*
- `npm run lint`
- `npm test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689182cf5cc083299b572b6609bbac7a