### PR TITLE
Enhance portfolio styling and navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Projects from './components/Projects.jsx'
 import Education from './components/Education.jsx'
 import Skills from './components/Skills.jsx'
 import Interests from './components/Interests.jsx'
+import BackToTopButton from './components/BackToTopButton.jsx'
 import Footer from './components/Footer.jsx'
 
 function App() {
@@ -18,6 +19,7 @@ function App() {
       <Education />
       <Skills />
       <Interests />
+      <BackToTopButton />
       <Footer />
     </>
   )

--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react'
+
+export default function BackToTopButton() {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setVisible(window.pageYOffset > 300)
+    }
+
+    window.addEventListener('scroll', toggleVisibility)
+    return () => window.removeEventListener('scroll', toggleVisibility)
+  }, [])
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  if (!visible) return null
+
+  return (
+    <button className="back-to-top" onClick={scrollToTop} aria-label="Back to top">
+      ↑
+    </button>
+  )
+}
+

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -1,6 +1,6 @@
 export default function Education() {
   return (
-    <section>
+    <section id="education">
       <h2>Education</h2>
       <ul>
         <li>

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,6 +1,6 @@
 export default function Experience() {
   return (
-    <section>
+    <section id="experience">
       <h2>Experience</h2>
       <h3>AI Intern — Reyes Holdings LLC</h3>
       <p>June 2024 – Present</p>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -3,6 +3,14 @@ export default function Header() {
     <header>
       <h1>Mateusz Pawłowski</h1>
       <p>AI Intern &amp; Information Technology Student</p>
+      <nav>
+        <a href="#about">About</a>
+        <a href="#experience">Experience</a>
+        <a href="#projects">Projects</a>
+        <a href="#education">Education</a>
+        <a href="#skills">Skills</a>
+        <a href="#interests">Interests</a>
+      </nav>
     </header>
   )
 }

--- a/src/components/Interests.jsx
+++ b/src/components/Interests.jsx
@@ -1,6 +1,6 @@
 export default function Interests() {
   return (
-    <section>
+    <section id="interests">
       <h2>Interests</h2>
       <ul>
         <li>Chelsea FC supporter</li>

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -1,6 +1,6 @@
 export default function PersonalInfo() {
   return (
-    <section>
+    <section id="about">
       <h2>About Me</h2>
       <p>
         I'm a senior Information Technology student at DePaul University and an AI intern

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,6 +1,6 @@
 export default function Projects() {
   return (
-    <section>
+    <section id="projects">
       <h2>Projects</h2>
       <ul>
         <li>

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,24 +1,111 @@
 export default function Skills() {
   return (
-    <section>
+    <section id="skills">
       <h2>Skills</h2>
-      <p>
-        <strong>Backend:</strong> JavaScript, Python, Node.js, PHP, Java, C#
-      </p>
-      <p>
-        <strong>Frontend:</strong> HTML, CSS, React, Tailwind CSS, Vue.js
-      </p>
-      <p>
-        <strong>Databases:</strong> SQL, MongoDB
-      </p>
-      <p>
-        <strong>Platforms &amp; APIs:</strong> OneReach.ai, OpenAI, Anthropic Claude, Google
-        Gemini, Postman
-      </p>
-      <p>
-        <strong>Other:</strong> Workflow Documentation, API Integration, Frontend
-        Development
-      </p>
+
+      <h3>Backend</h3>
+      <ul className="skills-list">
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg" alt="JavaScript" />
+          <span>JavaScript</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg" alt="Python" />
+          <span>Python</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg" alt="Node.js" />
+          <span>Node.js</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/php/php-original.svg" alt="PHP" />
+          <span>PHP</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="Java" />
+          <span>Java</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/csharp/csharp-original.svg" alt="C#" />
+          <span>C#</span>
+        </li>
+      </ul>
+
+      <h3>Frontend</h3>
+      <ul className="skills-list">
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg" alt="HTML5" />
+          <span>HTML5</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg" alt="CSS3" />
+          <span>CSS3</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg" alt="React" />
+          <span>React</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg" alt="Tailwind CSS" />
+          <span>Tailwind CSS</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg" alt="Vue.js" />
+          <span>Vue.js</span>
+        </li>
+      </ul>
+
+      <h3>Databases</h3>
+      <ul className="skills-list">
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original.svg" alt="SQL" />
+          <span>SQL</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mongodb/mongodb-original.svg" alt="MongoDB" />
+          <span>MongoDB</span>
+        </li>
+      </ul>
+
+      <h3>Platforms &amp; APIs</h3>
+      <ul className="skills-list">
+        <li>
+          <span role="img" aria-label="OneReach.ai">⚙️</span>
+          <span>OneReach.ai</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/openai/openai-original.svg" alt="OpenAI" />
+          <span>OpenAI</span>
+        </li>
+        <li>
+          <span role="img" aria-label="Anthropic Claude">🤖</span>
+          <span>Anthropic Claude</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/google/google-original.svg" alt="Google Gemini" />
+          <span>Google Gemini</span>
+        </li>
+        <li>
+          <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg" alt="Postman" />
+          <span>Postman</span>
+        </li>
+      </ul>
+
+      <h3>Other</h3>
+      <ul className="skills-list">
+        <li>
+          <span role="img" aria-label="Documentation">📝</span>
+          <span>Workflow Documentation</span>
+        </li>
+        <li>
+          <span role="img" aria-label="API Integration">🔗</span>
+          <span>API Integration</span>
+        </li>
+        <li>
+          <span role="img" aria-label="Frontend Development">🎨</span>
+          <span>Frontend Development</span>
+        </li>
+      </ul>
     </section>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,17 +1,60 @@
+:root {
+  --primary: #1e3a8a;
+  --accent: #3a0ca3;
+  --background: #f0f4f8;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   color: #333;
-  background-color: #f8f9fa;
+  background-color: var(--background);
 }
 
-header,
-section,
-footer {
+header {
+  text-align: center;
+  padding: 2rem 1rem 1rem;
+  color: #fff;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+}
+
+nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+  background: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 8px 8px;
+  position: sticky;
+  top: 0;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  z-index: 1000;
+}
+
+nav a {
+  color: var(--primary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+nav a:hover {
+  color: var(--accent);
+}
+
+section {
   max-width: 800px;
-  margin: 0 auto;
-  padding: 1rem;
+  margin: 1rem auto;
+  padding: 1.5rem;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
 h1 {
@@ -20,13 +63,13 @@ h1 {
 }
 
 h2 {
-  color: #0d3b66;
-  border-bottom: 2px solid #0d3b66;
+  color: var(--primary);
+  border-bottom: 2px solid var(--primary);
   padding-bottom: 0.25rem;
 }
 
 a {
-  color: #0d3b66;
+  color: var(--primary);
 }
 
 footer {
@@ -34,5 +77,46 @@ footer {
   margin-top: 2rem;
   font-size: 0.9rem;
   color: #666;
+  padding: 1rem 0;
+  background: #fff;
+}
+
+.skills-list {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+.skills-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.skills-list img {
+  width: 24px;
+  height: 24px;
+}
+
+.back-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.3);
+}
+
+.back-to-top:hover {
+  background: var(--accent);
 }
 


### PR DESCRIPTION
## Summary
- Add top navigation bar with anchors to each portfolio section.
- Revamp skills section to display technology icons and reorganized groups.
- Introduce back-to-top button, smooth scrolling, and refreshed color palette.

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68918c59604c8329bfb97128827803fe