### PR TITLE
refactor: use named exports for components

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,19 +1,19 @@
 
 import { useState } from 'react'
-import Header from './components/Header.jsx'
-import PersonalInfo from './components/PersonalInfo.jsx'
-import Experience from './components/Experience.jsx'
-import Projects from './components/Projects.jsx'
-import Education from './components/Education.jsx'
-import Skills from './components/Skills.jsx'
-import Interests from './components/Interests.jsx'
-import BackToTopButton from './components/BackToTopButton.jsx'
-import Footer from './components/Footer.jsx'
-import Navbar from './components/Navbar.jsx'
+import { Header } from './components/Header.jsx'
+import { PersonalInfo } from './components/PersonalInfo.jsx'
+import { Experience } from './components/Experience.jsx'
+import { Projects } from './components/Projects.jsx'
+import { Education } from './components/Education.jsx'
+import { Skills } from './components/Skills.jsx'
+import { Interests } from './components/Interests.jsx'
+import { BackToTopButton } from './components/BackToTopButton.jsx'
+import { Footer } from './components/Footer.jsx'
+import { Navbar } from './components/Navbar.jsx'
 import { LanguageContext } from './context/LanguageContext.jsx'
 import { translations } from './i18n.js'
 
-function App() {
+export function App() {
   const [lang, setLang] = useState('en')
   const t = (path) => path.split('.').reduce((obj, key) => obj?.[key], translations[lang])
 
@@ -32,5 +32,3 @@ function App() {
     </LanguageContext.Provider>
   )
 }
-
-export default App

--- a/src/__tests__/App.test.jsx
+++ b/src/__tests__/App.test.jsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
-import App from '../App'
+import { App } from '../App'
 
 describe('App', () => {
   it('renders without crashing', () => {

--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 
-export default function BackToTopButton() {
+export function BackToTopButton() {
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function Education() {
+export function Education() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="education">

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function Experience() {
+export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="experience">

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function Footer() {
+export function Footer() {
   const { t } = useContext(LanguageContext)
   return <footer>{t('footer')}</footer>
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function Header() {
+export function Header() {
   const { t } = useContext(LanguageContext)
   return (
     <header>

--- a/src/components/Interests.jsx
+++ b/src/components/Interests.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function Interests() {
+export function Interests() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="interests">

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import { LanguageContext } from '../context/LanguageContext.jsx';
 
-export default function Navbar() {
+export function Navbar() {
   const { lang, setLang, t } = useContext(LanguageContext);
   const toggleLang = () => setLang(lang === 'en' ? 'pl' : 'en');
 

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function PersonalInfo() {
+export function PersonalInfo() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="about">

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -1,7 +1,7 @@
 import { useContext } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-export default function Projects() {
+export function Projects() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="projects">

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -49,7 +49,7 @@ const renderSkill = (skill) => (
   </li>
 )
 
-export default function Skills() {
+export function Skills() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="skills">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.jsx'
+import { App } from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,5 +6,11 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'jsdom'
+  },
+  esbuild: {
+    keepNames: true,
+  },
+  build: {
+    minify: false,
   }
 })


### PR DESCRIPTION
## Summary
- switch all components to named exports and update imports accordingly
- disable production minification and preserve function names in Vite config

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897348c86d48329a87b903783cd2d7e