### PR TITLE
Refactor skills and experience layout with Tailwind

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mateusz Pawlowski Portfolio</title>
+    <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -4,14 +4,22 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
-    <section id="experience">
-      <h2>{t('experience.title')}</h2>
-      <h3>
-        {t('experience.role')}
-        <img src="/reyes-holdings-logo.svg" alt="Reyes Holdings Logo" className="reyes-logo" />
-      </h3>
-      <p>{t('experience.date')}</p>
-      <ul>
+    <section id="experience" className="space-y-4">
+      <h2 className="text-2xl font-bold text-center">{t('experience.title')}</h2>
+
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <img
+          src="/reyes-holdings-logo.svg"
+          alt="Reyes Holdings Logo"
+          className="w-16 h-16 object-contain"
+        />
+        <div>
+          <p className="text-sm text-gray-600">{t('experience.date')}</p>
+          <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
+        </div>
+      </div>
+
+      <ul className="list-disc pl-5 space-y-2">
         {t('experience.bullets').map((item, idx) => (
           <li key={idx}>{item}</li>
         ))}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -38,47 +38,65 @@ const other = [
 ]
 
 const renderSkill = (skill) => (
-  <li key={skill.name} className="skill-item">
+  <li
+    key={skill.name}
+    className="flex flex-col items-center justify-center p-4 border rounded-lg bg-white shadow-sm"
+  >
     {skill.icon ? (
-      <img src={skill.icon} alt={skill.name} />
+      <img
+        src={skill.icon}
+        alt={skill.name}
+        className="w-12 h-12 mb-2 filter brightness-0"
+      />
     ) : (
-      <span role="img" aria-label={skill.name}>{skill.emoji}</span>
+      <span role="img" aria-label={skill.name} className="text-4xl mb-2">
+        {skill.emoji}
+      </span>
     )}
-    <span>{skill.name}</span>
-    <div className="skill-bar"><span style={{ width: `${skill.level}%` }}></span></div>
+    <span className="text-sm text-center">{skill.name}</span>
   </li>
 )
 
 export function Skills() {
   const { t } = useContext(LanguageContext)
   return (
-    <section id="skills">
-      <h2>{t('skills.title')}</h2>
+    <section id="skills" className="space-y-6">
+      <h2 className="text-2xl font-bold text-center">{t('skills.title')}</h2>
 
-      <h3>{t('skills.backend')}</h3>
-      <ul className="skills-list">
-        {backend.map(renderSkill)}
-      </ul>
+      <div>
+        <h3 className="text-xl font-semibold mb-2">{t('skills.backend')}</h3>
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {backend.map(renderSkill)}
+        </ul>
+      </div>
 
-      <h3>{t('skills.frontend')}</h3>
-      <ul className="skills-list">
-        {frontend.map(renderSkill)}
-      </ul>
+      <div>
+        <h3 className="text-xl font-semibold mb-2">{t('skills.frontend')}</h3>
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {frontend.map(renderSkill)}
+        </ul>
+      </div>
 
-      <h3>{t('skills.databases')}</h3>
-      <ul className="skills-list">
-        {databases.map(renderSkill)}
-      </ul>
+      <div>
+        <h3 className="text-xl font-semibold mb-2">{t('skills.databases')}</h3>
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {databases.map(renderSkill)}
+        </ul>
+      </div>
 
-      <h3>{t('skills.platforms')}</h3>
-      <ul className="skills-list">
-        {platforms.map(renderSkill)}
-      </ul>
+      <div>
+        <h3 className="text-xl font-semibold mb-2">{t('skills.platforms')}</h3>
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {platforms.map(renderSkill)}
+        </ul>
+      </div>
 
-      <h3>{t('skills.other')}</h3>
-      <ul className="skills-list">
-        {other.map(renderSkill)}
-      </ul>
+      <div>
+        <h3 className="text-xl font-semibold mb-2">{t('skills.other')}</h3>
+        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
+          {other.map(renderSkill)}
+        </ul>
+      </div>
     </section>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -94,46 +94,6 @@ footer {
   background: #fff;
 }
 
-.skills-list {
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  padding: 0;
-  margin: 0 0 1rem 0;
-}
-
-.skills-list li {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex: 1 1 45%;
-}
-
-.skills-list img {
-  width: 24px;
-  height: 24px;
-}
-
-.skill-bar {
-  flex: 1;
-  height: 8px;
-  background: #e5e7eb;
-  border-radius: 4px;
-  overflow: hidden;
-}
-
-.skill-bar span {
-  display: block;
-  height: 100%;
-  background: var(--primary);
-}
-
-.reyes-logo {
-  height: 40px;
-  margin-left: 0.5rem;
-  vertical-align: middle;
-}
 
 .interests-grid {
   list-style: none;


### PR DESCRIPTION
## Summary
- Replace skill progress bars with responsive icon grid using Tailwind
- Redesign experience section to show logo, dates and role with modern layout
- Load Tailwind via CDN for improved styling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689738ba1b008329ae4004ac65e8c7ca