### PR TITLE
feat: restore top-floating navbar with language switcher

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,101 +1,74 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-const backend = [
-  { name: 'JavaScript', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg' },
-  { name: 'Python', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg' },
-  { name: 'Node.js', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg' },
-  { name: 'PHP', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/php/php-original.svg' },
-  { name: 'Java', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg' },
-  { name: 'C#', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/csharp/csharp-original.svg' }
-]
+export function Navbar() {
+  const { lang, setLang, t } = useContext(LanguageContext)
+  const [active, setActive] = useState('about')
+  const [open, setOpen] = useState(false)
 
-const frontend = [
-  { name: 'HTML5', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg' },
-  { name: 'CSS3', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg' },
-  { name: 'React', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg' },
-  { name: 'Tailwind CSS', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg' },
-  { name: 'Vue.js', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg' }
-]
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return
+    const sections = document.querySelectorAll('section[id]')
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActive(entry.target.id)
+        })
+      },
+      { threshold: 0.5 }
+    )
+    sections.forEach((section) => observer.observe(section))
+    return () => sections.forEach((section) => observer.unobserve(section))
+  }, [])
 
-const databases = [
-  { name: 'SQL', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original.svg' },
-  { name: 'MongoDB', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mongodb/mongodb-original.svg' }
-]
+  const langs = [
+    { code: 'en', flag: '🇺🇸', label: 'English' },
+    { code: 'pl', flag: '🇵🇱', label: 'Polski' }
+  ]
 
-const platforms = [
-  { name: 'OneReach.ai', emoji: '⚙️' },
-  { name: 'OpenAI', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/openai/openai-original.svg' },
-  { name: 'Anthropic Claude', emoji: '🤖' },
-  { name: 'Google Gemini', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/google/google-original.svg' },
-  { name: 'Postman', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg' }
-]
-
-const other = [
-  { name: 'Workflow Documentation', emoji: '📝' },
-  { name: 'API Integration', emoji: '🔗' },
-  { name: 'Frontend Development', emoji: '🎨' }
-]
-
-const renderSkill = (skill) => (
-  <li key={skill.name} className="flex items-center gap-2 p-3 border rounded-md bg-white shadow-sm">
-    {skill.icon ? (
-      <img
-        src={skill.icon}
-        alt={skill.name}
-        className="w-6 h-6 filter brightness-0"
-        loading="lazy"
-        width="24"
-        height="24"
-      />
-    ) : (
-      <span role="img" aria-label={skill.name} className="text-xl">{skill.emoji}</span>
-    )}
-    <span className="text-sm">{skill.name}</span>
-  </li>
-)
-
-export function Skills() {
-  const { t } = useContext(LanguageContext)
+  const links = ['about', 'experience', 'projects', 'education', 'skills']
 
   return (
-    <section id="skills" className="max-w-4xl mx-auto my-8 space-y-6">
-      <h2 className="text-2xl font-bold text-center">{t('skills.title')}</h2>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.backend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {backend.map(renderSkill)}
-        </ul>
+    <nav className="fixed left-1/2 top-4 -translate-x-1/2 z-50">
+      <div className="flex items-center space-x-4 bg-white/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg">
+        {links.map((key) => (
+          <a
+            key={key}
+            href={`#${key}`}
+            className={`px-3 py-2 rounded-md transition transform hover:scale-110 ${
+              active === key ? 'bg-gray-200' : ''
+            }`}
+          >
+            {t(`nav.${key}`)}
+          </a>
+        ))}
+        <div className="relative">
+          <button
+            onClick={() => setOpen(!open)}
+            className="w-12 h-12 rounded-full bg-white shadow-lg flex items-center justify-center text-2xl hover:scale-110 transition"
+          >
+            {lang === 'en' ? '🇺🇸' : '🇵🇱'}
+          </button>
+          {open && (
+            <ul className="absolute right-0 mt-2 bg-white rounded-md shadow-lg overflow-hidden">
+              {langs.map((l) => (
+                <li key={l.code}>
+                  <button
+                    onClick={() => {
+                      setLang(l.code)
+                      setOpen(false)
+                    }}
+                    className="flex items-center space-x-2 px-3 py-2 hover:bg-gray-100 w-full"
+                  >
+                    <span className="text-xl">{l.flag}</span>
+                    <span>{l.label}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.frontend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {frontend.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.databases')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {databases.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.platforms')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {platforms.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.other')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {other.map(renderSkill)}
-        </ul>
-      </div>
-    </section>
+    </nav>
   )
 }


### PR DESCRIPTION
## Summary
- revive navbar with Apple dock-inspired styling at top of page
- add dropdown language selector inside navbar

## Testing
- `npm test -- --run`
- `npm run lint`
