### PR TITLE
feat: revamp skills and project sections

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -4,29 +4,29 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
-    <section
-      id="experience"
-      className="max-w-3xl mx-auto my-8 p-6 bg-white rounded-lg shadow space-y-4"
-    >
-      <h2 className="text-2xl font-bold text-center">{t('experience.title')}</h2>
-
-      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <img
-          src="/reyes-holdings-logo.svg"
-          alt="Reyes Holdings Logo"
-          className="w-16 h-16 object-contain"
-        />
-        <div>
-          <p className="text-sm text-gray-600">{t('experience.date')}</p>
-          <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
+    <section id="experience" className="max-w-3xl mx-auto my-16">
+      <h2 className="text-3xl font-bold text-center mb-8">{t('experience.title')}</h2>
+      <div className="relative pl-10">
+        <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-blue-300 to-purple-300"></div>
+        <div className="relative mb-8 p-6 bg-white rounded-xl shadow">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex items-center space-x-3">
+              <img
+                src="/reyes-holdings-logo.svg"
+                alt="Reyes Holdings Logo"
+                className="w-12 h-12 object-contain"
+              />
+              <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
+            </div>
+            <span className="text-sm text-gray-600">{t('experience.date')}</span>
+          </div>
+          <ul className="list-disc pl-5 space-y-2 text-gray-700">
+            {t('experience.bullets').map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
         </div>
       </div>
-
-      <ul className="list-disc pl-5 space-y-2">
-        {t('experience.bullets').map((item, idx) => (
-          <li key={idx}>{item}</li>
-        ))}
-      </ul>
     </section>
   )
 }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,101 +1,74 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-const backend = [
-  { name: 'JavaScript', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg' },
-  { name: 'Python', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg' },
-  { name: 'Node.js', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg' },
-  { name: 'PHP', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/php/php-original.svg' },
-  { name: 'Java', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg' },
-  { name: 'C#', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/csharp/csharp-original.svg' }
-]
+export function Navbar() {
+  const { lang, setLang, t } = useContext(LanguageContext)
+  const [active, setActive] = useState('about')
+  const [open, setOpen] = useState(false)
 
-const frontend = [
-  { name: 'HTML5', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg' },
-  { name: 'CSS3', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg' },
-  { name: 'React', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg' },
-  { name: 'Tailwind CSS', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg' },
-  { name: 'Vue.js', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg' }
-]
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return
+    const sections = document.querySelectorAll('section[id]')
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActive(entry.target.id)
+        })
+      },
+      { threshold: 0.5 }
+    )
+    sections.forEach((section) => observer.observe(section))
+    return () => sections.forEach((section) => observer.unobserve(section))
+  }, [])
 
-const databases = [
-  { name: 'SQL', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original.svg' },
-  { name: 'MongoDB', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mongodb/mongodb-original.svg' }
-]
+  const langs = [
+    { code: 'en', flag: '🇺🇸', label: 'English' },
+    { code: 'pl', flag: '🇵🇱', label: 'Polski' }
+  ]
 
-const platforms = [
-  { name: 'OneReach.ai', emoji: '⚙️' },
-  { name: 'OpenAI', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/openai/openai-original.svg' },
-  { name: 'Anthropic Claude', emoji: '🤖' },
-  { name: 'Google Gemini', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/google/google-original.svg' },
-  { name: 'Postman', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg' }
-]
-
-const other = [
-  { name: 'Workflow Documentation', emoji: '📝' },
-  { name: 'API Integration', emoji: '🔗' },
-  { name: 'Frontend Development', emoji: '🎨' }
-]
-
-const renderSkill = (skill) => (
-  <li key={skill.name} className="flex items-center gap-2 p-3 border rounded-md bg-white shadow-sm">
-    {skill.icon ? (
-      <img
-        src={skill.icon}
-        alt={skill.name}
-        className="w-6 h-6 filter brightness-0"
-        loading="lazy"
-        width="24"
-        height="24"
-      />
-    ) : (
-      <span role="img" aria-label={skill.name} className="text-xl">{skill.emoji}</span>
-    )}
-    <span className="text-sm">{skill.name}</span>
-  </li>
-)
-
-export function Skills() {
-  const { t } = useContext(LanguageContext)
+  const links = ['about', 'experience', 'projects', 'education', 'skills']
 
   return (
-    <section id="skills" className="max-w-4xl mx-auto my-8 space-y-6">
-      <h2 className="text-2xl font-bold text-center">{t('skills.title')}</h2>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.backend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {backend.map(renderSkill)}
-        </ul>
+    <nav className="fixed left-1/2 top-4 -translate-x-1/2 z-50">
+      <div className="flex items-center space-x-4 bg-white/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg">
+        {links.map((key) => (
+          <a
+            key={key}
+            href={`#${key}`}
+            className={`px-3 py-2 rounded-md transition transform hover:scale-110 ${
+              active === key ? 'bg-gray-200' : ''
+            }`}
+          >
+            {t(`nav.${key}`)}
+          </a>
+        ))}
+        <div className="relative">
+          <button
+            onClick={() => setOpen(!open)}
+            className="w-12 h-12 rounded-full bg-white shadow-lg flex items-center justify-center text-2xl hover:scale-110 transition"
+          >
+            {lang === 'en' ? '🇺🇸' : '🇵🇱'}
+          </button>
+          {open && (
+            <ul className="absolute right-0 mt-2 bg-white rounded-md shadow-lg overflow-hidden">
+              {langs.map((l) => (
+                <li key={l.code}>
+                  <button
+                    onClick={() => {
+                      setLang(l.code)
+                      setOpen(false)
+                    }}
+                    className="flex items-center space-x-2 px-3 py-2 hover:bg-gray-100 w-full"
+                  >
+                    <span className="text-xl">{l.flag}</span>
+                    <span>{l.label}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
       </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.frontend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {frontend.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.databases')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {databases.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.platforms')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {platforms.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.other')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {other.map(renderSkill)}
-        </ul>
-      </div>
-    </section>
+    </nav>
   )
 }

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -31,6 +31,15 @@ export function PersonalInfo() {
         >
           {t('about.linkText')}
         </a>
+        <span aria-hidden>•</span>
+        <a
+          href="https://github.com/Mpawlowski5467"
+          className="text-blue-600 underline"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t('about.github')}
+        </a>
       </p>
 
       <div className="mt-6">

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -8,7 +8,17 @@ export function Projects() {
       <h2 className="text-3xl font-bold text-center mb-6">{t('projects.title')}</h2>
       <div className="grid gap-6 md:grid-cols-2">
         {t('projects.items').map((proj, idx) => (
-          <div key={idx} className="p-4 bg-white rounded-lg shadow">
+          <div key={idx} className="relative p-4 bg-white rounded-lg shadow hover:shadow-lg transition-shadow">
+            {proj.link && (
+              <a
+                href={proj.link}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="absolute top-2 right-2 text-sm bg-blue-600 text-white px-2 py-1 rounded hover:bg-blue-700"
+              >
+                {t('projects.github')}
+              </a>
+            )}
             <h3 className="text-xl font-semibold mb-2">{proj.name}</h3>
             <p>{proj.desc}</p>
           </div>

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
 const backend = [
@@ -38,80 +38,59 @@ const other = [
   { name: 'Frontend Development', emoji: '🎨' }
 ]
 
-// If you want a single “All Skills” grid instead, uncomment this:
-// const skills = [...backend, ...frontend, ...databases, ...platforms, ...other]
-
-const renderSkill = (skill) => (
-  <li
-    key={skill.name}
-    className="flex items-center p-3 border rounded-md bg-white shadow-sm"
-  >
-    {skill.icon ? (
-      <img
-        src={skill.icon}
-        alt={skill.name}
-        className="w-6 h-6 filter brightness-0"
-        loading="lazy"
-        width="24"
-        height="24"
-      />
-    ) : (
-      <span role="img" aria-label={skill.name} className="text-xl">
-        {skill.emoji}
-      </span>
-    )}
-    <span className="mx-1">:</span>
-    <span className="text-sm">{skill.name}</span>
-  </li>
-)
+const skills = [...backend, ...frontend, ...databases, ...platforms, ...other]
 
 export function Skills() {
   const { t } = useContext(LanguageContext)
+  const ref = useRef(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof window === 'undefined' || !('IntersectionObserver' in window)) return
+    const observer = new IntersectionObserver(
+      ([entry]) => entry.isIntersecting && setVisible(true),
+      { threshold: 0.3 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <section id="skills" className="max-w-4xl mx-auto my-8 space-y-6">
-      <h2 className="text-2xl font-bold text-center">{t('skills.title')}</h2>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.backend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {backend.map(renderSkill)}
-        </ul>
+    <section
+      id="skills"
+      ref={ref}
+      className={`max-w-4xl mx-auto my-20 p-8 rounded-xl shadow-lg bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 transition-all duration-700 ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+      }`}
+    >
+      <h2 className="text-3xl font-bold text-center mb-8">{t('skills.title')}</h2>
+      <div className="relative w-72 h-72 mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-white/70 shadow-inner">
+        {skills.map((skill) => (
+          <div key={skill.name} className="flex items-center justify-center">
+            {skill.icon ? (
+              <img
+                src={skill.icon}
+                alt={skill.name}
+                title={skill.name}
+                className="w-12 h-12 transition-transform hover:scale-110"
+                loading="lazy"
+                width="48"
+                height="48"
+              />
+            ) : (
+              <span
+                role="img"
+                aria-label={skill.name}
+                title={skill.name}
+                className="text-4xl"
+              >
+                {skill.emoji}
+              </span>
+            )}
+          </div>
+        ))}
       </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.frontend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {frontend.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.databases')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {databases.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.platforms')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {platforms.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.other')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {other.map(renderSkill)}
-        </ul>
-      </div>
-
-      {/* If you prefer one big grid, replace everything between <section> and </section> with:
-      <h2 className="text-2xl font-bold text-center mb-4">{t('skills.title')}</h2>
-      <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-        {skills.map(renderSkill)}
-      </ul>
-      */}
     </section>
   )
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,7 +16,8 @@ export const translations = {
       p1: "I'm a senior Information Technology student at DePaul University and an AI intern at Reyes Holdings. I enjoy building intelligent systems that improve user experience and efficiency.",
       location: 'Prospect Heights, IL',
       email: 'mpawlowski5467@gmail.com',
-      linkText: 'LinkedIn'
+      linkText: 'LinkedIn',
+      github: 'GitHub'
     },
     experience: {
       title: 'Experience',
@@ -32,18 +33,22 @@ export const translations = {
     },
     projects: {
       title: 'Projects',
+      github: 'GitHub',
       items: [
         {
           name: 'Jan III Sobieski Polish School Website',
-          desc: 'Redesigned the public site with modern UI themes and improved navigation.'
+          desc: 'Redesigned the public site with modern UI themes and improved navigation.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Car Parts E-commerce Platform',
-          desc: 'Full-stack application using JavaScript, Node.js, and MongoDB for online auto-parts sales.'
+          desc: 'Full-stack application using JavaScript, Node.js, and MongoDB for online auto-parts sales.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Chicago Event-Ticketing Website',
-          desc: 'Developing a platform for browsing and purchasing tickets to Chicago-area events.'
+          desc: 'Developing a platform for browsing and purchasing tickets to Chicago-area events.',
+          link: 'https://github.com/Mpawlowski5467'
         }
       ]
     },
@@ -94,7 +99,8 @@ export const translations = {
       p1: 'Jestem starszym studentem informatyki na Uniwersytecie DePaul oraz stażystą AI w Reyes Holdings. Lubię tworzyć inteligentne systemy, które poprawiają doświadczenie użytkownika i zwiększają wydajność.',
       location: 'Prospect Heights, IL',
       email: 'mpawlowski5467@gmail.com',
-      linkText: 'LinkedIn'
+      linkText: 'LinkedIn',
+      github: 'GitHub'
     },
     experience: {
       title: 'Doświadczenie',
@@ -110,18 +116,22 @@ export const translations = {
     },
     projects: {
       title: 'Projekty',
+      github: 'GitHub',
       items: [
         {
           name: 'Strona szkoły polskiej im. Jana III Sobieskiego',
-          desc: 'Przeprojektowana witryna publiczna z nowoczesnym interfejsem i ulepszoną nawigacją.'
+          desc: 'Przeprojektowana witryna publiczna z nowoczesnym interfejsem i ulepszoną nawigacją.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Platforma e-commerce z częściami samochodowymi',
-          desc: 'Aplikacja full-stack wykorzystująca JavaScript, Node.js i MongoDB do sprzedaży części samochodowych online.'
+          desc: 'Aplikacja full-stack wykorzystująca JavaScript, Node.js i MongoDB do sprzedaży części samochodowych online.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Witryna z biletami na wydarzenia w Chicago',
-          desc: 'Tworzenie platformy do przeglądania i kupowania biletów na wydarzenia w okolicach Chicago.'
+          desc: 'Tworzenie platformy do przeglądania i kupowania biletów na wydarzenia w okolicach Chicago.',
+          link: 'https://github.com/Mpawlowski5467'
         }
       ]
     },


### PR DESCRIPTION
## Summary
- combine all skills into a circular cluster with scroll-triggered animation
- add GitHub profile link and per-project GitHub buttons
- restyle experience section with timeline-inspired layout

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898b4ee38a88329af8b150b4c90608f