### PR TITLE
feat: revamp skills and project sections

### DIFF
--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -4,19 +4,19 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Education() {
   const { t } = useContext(LanguageContext)
   return (
-    <section
-      id="education"
-      className="max-w-3xl mx-auto my-8 p-6 bg-white rounded-lg shadow"
-    >
-      <h2 className="text-2xl font-bold mb-4 text-center">
-        {t('education.title')}
-      </h2>
-      <ul className="list-disc pl-5 space-y-2">
-        {t('education.items').map((item, idx) => (
-          <li key={idx}>{item}</li>
-        ))}
-      </ul>
-    </section>
+      <section
+        id="education"
+        className="max-w-3xl mx-auto my-8 p-6 bg-[var(--honeydew)] rounded-lg shadow text-[var(--rich-black)]"
+      >
+        <h2 className="text-2xl font-bold mb-4 text-center text-[var(--dark-purple)]">
+          {t('education.title')}
+        </h2>
+        <ul className="list-disc pl-5 space-y-2">
+          {t('education.items').map((item, idx) => (
+            <li key={idx}>{item}</li>
+          ))}
+        </ul>
+      </section>
   )
 }
 

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -4,30 +4,30 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
-    <section
-      id="experience"
-      className="max-w-3xl mx-auto my-8 p-6 bg-white rounded-lg shadow space-y-4"
-    >
-      <h2 className="text-2xl font-bold text-center">{t('experience.title')}</h2>
-
-      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
-        <img
-          src="/reyes-holdings-logo.svg"
-          alt="Reyes Holdings Logo"
-          className="w-16 h-16 object-contain"
-        />
-        <div>
-          <p className="text-sm text-gray-600">{t('experience.date')}</p>
-          <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
+      <section id="experience" className="max-w-3xl mx-auto my-16">
+        <h2 className="text-3xl font-bold text-center mb-8 text-[var(--dark-purple)]">{t('experience.title')}</h2>
+        <div className="relative pl-10">
+          <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-[var(--naples-yellow)] to-[var(--dark-purple)]"></div>
+          <div className="relative mb-8 p-6 bg-[var(--honeydew)] rounded-xl shadow">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center space-x-3">
+                <img
+                  src="/reyes-holdings-logo.svg"
+                  alt="Reyes Holdings Logo"
+                  className="w-12 h-12 object-contain"
+                />
+                <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
+              </div>
+              <span className="text-sm text-[var(--ash-gray)]">{t('experience.date')}</span>
+            </div>
+            <ul className="list-disc pl-5 space-y-2 text-[var(--rich-black)]">
+              {t('experience.bullets').map((item, idx) => (
+                <li key={idx}>{item}</li>
+              ))}
+            </ul>
+          </div>
         </div>
-      </div>
-
-      <ul className="list-disc pl-5 space-y-2">
-        {t('experience.bullets').map((item, idx) => (
-          <li key={idx}>{item}</li>
-        ))}
-      </ul>
-    </section>
+      </section>
   )
 }
 

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,9 +4,9 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Footer() {
   const { t } = useContext(LanguageContext)
   const lastUpdated = new Date().toLocaleDateString()
-  return (
-    <footer className="text-center py-4 text-sm text-gray-600">
-      {t('footer.name')} — {t('footer.updated')}: {lastUpdated}
-    </footer>
-  )
-}
+    return (
+      <footer className="text-center py-4 text-sm bg-[var(--rich-black)] text-[var(--honeydew)]">
+        {t('footer.name')} — {t('footer.updated')}: {lastUpdated}
+      </footer>
+    )
+  }

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,101 +1,74 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
-const backend = [
-  { name: 'JavaScript', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/javascript/javascript-original.svg' },
-  { name: 'Python', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/python/python-original.svg' },
-  { name: 'Node.js', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/nodejs/nodejs-original.svg' },
-  { name: 'PHP', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/php/php-original.svg' },
-  { name: 'Java', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg' },
-  { name: 'C#', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/csharp/csharp-original.svg' }
-]
+export function Navbar() {
+  const { lang, setLang, t } = useContext(LanguageContext)
+  const [active, setActive] = useState('about')
+  const [open, setOpen] = useState(false)
 
-const frontend = [
-  { name: 'HTML5', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/html5/html5-original.svg' },
-  { name: 'CSS3', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/css3/css3-original.svg' },
-  { name: 'React', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/react/react-original.svg' },
-  { name: 'Tailwind CSS', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/tailwindcss/tailwindcss-original.svg' },
-  { name: 'Vue.js', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vuejs/vuejs-original.svg' }
-]
+  useEffect(() => {
+    if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return
+    const sections = document.querySelectorAll('section[id]')
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActive(entry.target.id)
+        })
+      },
+      { threshold: 0.5 }
+    )
+    sections.forEach((section) => observer.observe(section))
+    return () => sections.forEach((section) => observer.unobserve(section))
+  }, [])
 
-const databases = [
-  { name: 'SQL', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mysql/mysql-original.svg' },
-  { name: 'MongoDB', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mongodb/mongodb-original.svg' }
-]
+  const langs = [
+    { code: 'en', flag: '🇺🇸', label: 'English' },
+    { code: 'pl', flag: '🇵🇱', label: 'Polski' }
+  ]
 
-const platforms = [
-  { name: 'OneReach.ai', emoji: '⚙️' },
-  { name: 'OpenAI', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/openai/openai-original.svg' },
-  { name: 'Anthropic Claude', emoji: '🤖' },
-  { name: 'Google Gemini', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/google/google-original.svg' },
-  { name: 'Postman', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg' }
-]
+  const links = ['about', 'experience', 'projects', 'education', 'skills']
 
-const other = [
-  { name: 'Workflow Documentation', emoji: '📝' },
-  { name: 'API Integration', emoji: '🔗' },
-  { name: 'Frontend Development', emoji: '🎨' }
-]
-
-const renderSkill = (skill) => (
-  <li key={skill.name} className="flex items-center gap-2 p-3 border rounded-md bg-white shadow-sm">
-    {skill.icon ? (
-      <img
-        src={skill.icon}
-        alt={skill.name}
-        className="w-6 h-6 filter brightness-0"
-        loading="lazy"
-        width="24"
-        height="24"
-      />
-    ) : (
-      <span role="img" aria-label={skill.name} className="text-xl">{skill.emoji}</span>
-    )}
-    <span className="text-sm">{skill.name}</span>
-  </li>
-)
-
-export function Skills() {
-  const { t } = useContext(LanguageContext)
-
-  return (
-    <section id="skills" className="max-w-4xl mx-auto my-8 space-y-6">
-      <h2 className="text-2xl font-bold text-center">{t('skills.title')}</h2>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.backend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {backend.map(renderSkill)}
-        </ul>
+    return (
+      <nav className="fixed left-1/2 top-4 -translate-x-1/2 z-50">
+        <div className="flex items-center space-x-4 bg-[var(--honeydew)]/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg text-[var(--rich-black)]">
+        {links.map((key) => (
+          <a
+            key={key}
+            href={`#${key}`}
+              className={`px-3 py-2 rounded-md transition transform hover:scale-110 ${
+                active === key ? 'bg-[var(--naples-yellow)] text-[var(--rich-black)]' : ''
+              }`}
+          >
+            {t(`nav.${key}`)}
+          </a>
+        ))}
+          <div className="relative">
+            <button
+              onClick={() => setOpen(!open)}
+              className="w-12 h-12 rounded-full bg-[var(--naples-yellow)] text-[var(--rich-black)] shadow-lg flex items-center justify-center text-2xl hover:scale-110 transition"
+            >
+              {lang === 'en' ? '🇺🇸' : '🇵🇱'}
+            </button>
+            {open && (
+              <ul className="absolute right-0 mt-2 bg-[var(--honeydew)] rounded-md shadow-lg overflow-hidden text-[var(--rich-black)]">
+                {langs.map((l) => (
+                  <li key={l.code}>
+                    <button
+                      onClick={() => {
+                        setLang(l.code)
+                        setOpen(false)
+                      }}
+                      className="flex items-center space-x-2 px-3 py-2 hover:bg-[var(--naples-yellow)] w-full"
+                    >
+                      <span className="text-xl">{l.flag}</span>
+                      <span>{l.label}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
       </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.frontend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {frontend.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.databases')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {databases.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.platforms')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {platforms.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.other')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {other.map(renderSkill)}
-        </ul>
-      </div>
-    </section>
+    </nav>
   )
 }

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -10,32 +10,43 @@ export function PersonalInfo() {
   const interestItems = Array.isArray(interests) ? interests : []
 
   return (
-    <section id="about" className="pt-24 max-w-3xl mx-auto my-8 space-y-4 text-center">
-      <h1 className="text-4xl font-bold">{t('header.name')}</h1>
-      <p className="text-xl text-gray-600">{t('header.role')}</p>
+    <section id="about" className="pt-24 max-w-5xl mx-auto my-8 grid gap-8 md:grid-cols-2 items-start">
+      <div className="space-y-4 text-center md:text-left">
+        <h1 className="text-4xl font-bold">{t('header.name')}</h1>
+        <p className="text-xl text-[var(--ash-gray)]">{t('header.role')}</p>
 
-      <h2 className="text-3xl font-bold mt-6">{t('about.title')}</h2>
-      <p className="text-lg">{t('about.p1')}</p>
-      <p className="text-gray-700">{t('about.location')}</p>
+        <h2 className="text-3xl font-bold mt-6">{t('about.title')}</h2>
+        <p className="text-lg">{t('about.p1')}</p>
+        <p className="text-[var(--rich-black)]">{t('about.location')}</p>
 
-      <p className="space-x-2">
-        <a href="mailto:mpawlowski5467@gmail.com" className="text-blue-600 underline">
-          {t('about.email')}
-        </a>
-        <span aria-hidden>•</span>
-        <a
-          href="https://www.linkedin.com/in/mateusz-pawlowski-823849302/"
-          className="text-blue-600 underline"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {t('about.linkText')}
-        </a>
-      </p>
+        <p className="space-x-2">
+          <a href="mailto:mpawlowski5467@gmail.com" className="text-[var(--dark-purple)] underline">
+            {t('about.email')}
+          </a>
+          <span aria-hidden>•</span>
+          <a
+            href="https://www.linkedin.com/in/mateusz-pawlowski-823849302/"
+            className="text-[var(--dark-purple)] underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t('about.linkText')}
+          </a>
+          <span aria-hidden>•</span>
+          <a
+            href="https://github.com/Mpawlowski5467"
+            className="text-[var(--dark-purple)] underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {t('about.github')}
+          </a>
+        </p>
+      </div>
 
-      <div className="mt-6">
-        <h3 className="text-2l font-semibold text-2xl">{t('interests.title')}</h3>
-        <ul className="flex flex-wrap justify-center gap-4 mt-2">
+      <div className="mt-6 md:mt-0 text-center md:text-left">
+        <h3 className="text-2xl font-semibold text-[var(--dark-purple)]">{t('interests.title')}</h3>
+        <ul className="flex flex-wrap justify-center md:justify-start gap-4 mt-2">
           {interestItems.map((item, idx) => (
             <li key={item?.text ?? idx} className="flex items-center space-x-2">
               {item?.icon && (

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -4,17 +4,27 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Projects() {
   const { t } = useContext(LanguageContext)
   return (
-    <section id="projects" className="max-w-4xl mx-auto my-8">
-      <h2 className="text-3xl font-bold text-center mb-6">{t('projects.title')}</h2>
-      <div className="grid gap-6 md:grid-cols-2">
-        {t('projects.items').map((proj, idx) => (
-          <div key={idx} className="p-4 bg-white rounded-lg shadow">
-            <h3 className="text-xl font-semibold mb-2">{proj.name}</h3>
-            <p>{proj.desc}</p>
-          </div>
-        ))}
-      </div>
-    </section>
+      <section id="projects" className="max-w-4xl mx-auto my-8">
+        <h2 className="text-3xl font-bold text-center mb-6 text-[var(--dark-purple)]">{t('projects.title')}</h2>
+        <div className="grid gap-6 md:grid-cols-2">
+          {t('projects.items').map((proj, idx) => (
+            <div key={idx} className="relative p-4 bg-[var(--honeydew)] rounded-lg shadow hover:shadow-lg transition-shadow text-[var(--rich-black)]">
+              {proj.link && (
+                <a
+                  href={proj.link}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="absolute top-2 right-2 text-sm bg-[var(--naples-yellow)] text-[var(--rich-black)] px-2 py-1 rounded hover:bg-[var(--dark-purple)] hover:text-[var(--honeydew)]"
+                >
+                  {t('projects.github')}
+                </a>
+              )}
+              <h3 className="text-xl font-semibold mb-2">{proj.name}</h3>
+              <p>{proj.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
   )
 }
 

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 import { LanguageContext } from '../context/LanguageContext.jsx'
 
 const backend = [
@@ -38,80 +38,60 @@ const other = [
   { name: 'Frontend Development', emoji: '🎨' }
 ]
 
-// If you want a single “All Skills” grid instead, uncomment this:
-// const skills = [...backend, ...frontend, ...databases, ...platforms, ...other]
-
-const renderSkill = (skill) => (
-  <li
-    key={skill.name}
-    className="flex items-center p-3 border rounded-md bg-white shadow-sm"
-  >
-    {skill.icon ? (
-      <img
-        src={skill.icon}
-        alt={skill.name}
-        className="w-6 h-6 filter brightness-0"
-        loading="lazy"
-        width="24"
-        height="24"
-      />
-    ) : (
-      <span role="img" aria-label={skill.name} className="text-xl">
-        {skill.emoji}
-      </span>
-    )}
-    <span className="mx-1">:</span>
-    <span className="text-sm">{skill.name}</span>
-  </li>
-)
+const skills = [...backend, ...frontend, ...databases, ...platforms, ...other]
 
 export function Skills() {
   const { t } = useContext(LanguageContext)
+  const ref = useRef(null)
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const el = ref.current
+    if (!el || typeof window === 'undefined' || !('IntersectionObserver' in window)) return
+    const observer = new IntersectionObserver(
+      ([entry]) => entry.isIntersecting && setVisible(true),
+      { threshold: 0.3 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <section id="skills" className="max-w-4xl mx-auto my-8 space-y-6">
-      <h2 className="text-2xl font-bold text-center">{t('skills.title')}</h2>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.backend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {backend.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.frontend')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {frontend.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.databases')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {databases.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.platforms')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {platforms.map(renderSkill)}
-        </ul>
-      </div>
-
-      <div>
-        <h3 className="text-xl font-semibold mb-2">{t('skills.other')}</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {other.map(renderSkill)}
-        </ul>
-      </div>
-
-      {/* If you prefer one big grid, replace everything between <section> and </section> with:
-      <h2 className="text-2xl font-bold text-center mb-4">{t('skills.title')}</h2>
-      <ul className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-        {skills.map(renderSkill)}
-      </ul>
-      */}
-    </section>
+    <section
+      id="skills"
+      ref={ref}
+      className={`max-w-4xl mx-auto my-20 p-8 rounded-xl shadow-lg bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 transition-all duration-700 ${
+        visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
+      }`}
+    >
+      <h2 className="text-3xl font-bold text-center mb-8">{t('skills.title')}</h2>
+        <div className="relative w-80 h-80 mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-[var(--honeydew)] shadow-inner overflow-hidden">
+          {skills.map((skill) => (
+            <div key={skill.name} className="relative group w-16 h-16 flex items-center justify-center">
+              {skill.icon ? (
+                <img
+                  src={skill.icon}
+                  alt={skill.name}
+                  className="w-12 h-12 transition-transform group-hover:scale-110"
+                  loading="lazy"
+                  width="48"
+                  height="48"
+                />
+              ) : (
+                <span
+                  role="img"
+                  aria-label={skill.name}
+                  className="text-4xl transition-transform group-hover:scale-110"
+                >
+                  {skill.emoji}
+                </span>
+              )}
+              <span className="absolute top-full mt-1 px-2 py-1 rounded bg-[var(--rich-black)] text-[var(--honeydew)] text-xs opacity-0 group-hover:opacity-100 whitespace-nowrap">
+                {skill.name}
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
   )
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -16,7 +16,8 @@ export const translations = {
       p1: "I'm a senior Information Technology student at DePaul University and an AI intern at Reyes Holdings. I enjoy building intelligent systems that improve user experience and efficiency.",
       location: 'Prospect Heights, IL',
       email: 'mpawlowski5467@gmail.com',
-      linkText: 'LinkedIn'
+      linkText: 'LinkedIn',
+      github: 'GitHub'
     },
     experience: {
       title: 'Experience',
@@ -32,18 +33,22 @@ export const translations = {
     },
     projects: {
       title: 'Projects',
+      github: 'GitHub',
       items: [
         {
           name: 'Jan III Sobieski Polish School Website',
-          desc: 'Redesigned the public site with modern UI themes and improved navigation.'
+          desc: 'Redesigned the public site with modern UI themes and improved navigation.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Car Parts E-commerce Platform',
-          desc: 'Full-stack application using JavaScript, Node.js, and MongoDB for online auto-parts sales.'
+          desc: 'Full-stack application using JavaScript, Node.js, and MongoDB for online auto-parts sales.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Chicago Event-Ticketing Website',
-          desc: 'Developing a platform for browsing and purchasing tickets to Chicago-area events.'
+          desc: 'Developing a platform for browsing and purchasing tickets to Chicago-area events.',
+          link: 'https://github.com/Mpawlowski5467'
         }
       ]
     },
@@ -94,7 +99,8 @@ export const translations = {
       p1: 'Jestem starszym studentem informatyki na Uniwersytecie DePaul oraz stażystą AI w Reyes Holdings. Lubię tworzyć inteligentne systemy, które poprawiają doświadczenie użytkownika i zwiększają wydajność.',
       location: 'Prospect Heights, IL',
       email: 'mpawlowski5467@gmail.com',
-      linkText: 'LinkedIn'
+      linkText: 'LinkedIn',
+      github: 'GitHub'
     },
     experience: {
       title: 'Doświadczenie',
@@ -110,18 +116,22 @@ export const translations = {
     },
     projects: {
       title: 'Projekty',
+      github: 'GitHub',
       items: [
         {
           name: 'Strona szkoły polskiej im. Jana III Sobieskiego',
-          desc: 'Przeprojektowana witryna publiczna z nowoczesnym interfejsem i ulepszoną nawigacją.'
+          desc: 'Przeprojektowana witryna publiczna z nowoczesnym interfejsem i ulepszoną nawigacją.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Platforma e-commerce z częściami samochodowymi',
-          desc: 'Aplikacja full-stack wykorzystująca JavaScript, Node.js i MongoDB do sprzedaży części samochodowych online.'
+          desc: 'Aplikacja full-stack wykorzystująca JavaScript, Node.js i MongoDB do sprzedaży części samochodowych online.',
+          link: 'https://github.com/Mpawlowski5467'
         },
         {
           name: 'Witryna z biletami na wydarzenia w Chicago',
-          desc: 'Tworzenie platformy do przeglądania i kupowania biletów na wydarzenia w okolicach Chicago.'
+          desc: 'Tworzenie platformy do przeglądania i kupowania biletów na wydarzenia w okolicach Chicago.',
+          link: 'https://github.com/Mpawlowski5467'
         }
       ]
     },

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,9 @@
 :root {
-  --primary: #1e3a8a;
-  --accent: #3a0ca3;
-  --background: #f0f4f8;
+  --dark-purple: #160c28ff;
+  --naples-yellow: #efcb68ff;
+  --honeydew: #e1efe6ff;
+  --ash-gray: #aeb7b3ff;
+  --rich-black: #000411ff;
 }
 
 html {
@@ -12,15 +14,15 @@ body {
   margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
-  color: #333;
-  background-color: var(--background);
+  color: var(--rich-black);
+  background-color: var(--honeydew);
 }
 
 header {
   text-align: center;
   padding: 2rem 1rem 1rem;
   color: #fff;
-  background: linear-gradient(135deg, var(--primary), var(--accent));
+  background: linear-gradient(135deg, var(--dark-purple), var(--naples-yellow));
 }
 
 h1 {
@@ -29,9 +31,9 @@ h1 {
 }
 
 h2 {
-  color: var(--primary);
+  color: var(--dark-purple);
 }
 
 a {
-  color: var(--primary);
+  color: var(--dark-purple);
 }


### PR DESCRIPTION
## Summary
- unify brand colors using dark purple and naples yellow palette across site
- expand skills cluster with hover tooltips for every icon
- rearrange about section into two-column layout for fuller feel

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898b4ee38a88329af8b150b4c90608f