### PR TITLE
style: refresh skills layout and theme

### DIFF
--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -12,7 +12,7 @@ export function Experience() {
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <img
-                src="/reyes-holdings-logo.svg"
+                src="https://media.licdn.com/dms/image/v2/C560BAQFz7AGAFLXN0A/company-logo_200_200/company-logo_200_200/0/1641580116422/reyes_holdings_logo?e=1757548800&v=beta&t=vwhRKm6AbE3K57Ehi5kVfCkeGYdDMh8RSut0N0lx9nM"
                 alt="Reyes Holdings Logo"
                 className="w-12 h-12 object-contain"
               />

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -60,12 +60,12 @@ export function Skills() {
     <section
       id="skills"
       ref={ref}
-      className={`max-w-4xl mx-auto my-20 p-8 rounded-xl shadow-lg bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50 transition-all duration-700 ${
+      className={`max-w-4xl mx-auto my-20 p-8 transition-all duration-700 ${
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
       }`}
     >
       <h2 className="text-3xl font-bold text-center mb-8">{t('skills.title')}</h2>
-      <div className="relative w-80 h-80 mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-[var(--honeydew)] shadow-inner overflow-hidden">
+      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-[var(--honeydew)] overflow-hidden">
         {skills.map((skill) => (
           <div key={skill.name} className="relative group w-16 h-16 flex items-center justify-center">
             {skill.icon ? (

--- a/src/index.css
+++ b/src/index.css
@@ -15,7 +15,7 @@ body {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   color: var(--rich-black);
-  background-color: var(--honeydew);
+  background-color: var(--ash-gray);
 }
 
 header {


### PR DESCRIPTION
## Summary
- enlarge skills circle and remove surrounding box
- swap Reyes logo to LinkedIn-hosted image
- darken page background for better contrast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898c62a870c8329b361b6e3724edecb