### PR TITLE
feat: apply new tailwind color theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,79 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mateusz Pawlowski Portfolio</title>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              teal: {
+                DEFAULT: '#177e89',
+                100: '#05191b',
+                200: '#093236',
+                300: '#0e4a51',
+                400: '#12636c',
+                500: '#177e89',
+                600: '#21b3c3',
+                700: '#4ad1e0',
+                800: '#87e1eb',
+                900: '#c3f0f5'
+              },
+              midnight_green: {
+                DEFAULT: '#084c61',
+                100: '#021014',
+                200: '#031f28',
+                300: '#052f3b',
+                400: '#063e4f',
+                500: '#084c61',
+                600: '#0e88ae',
+                700: '#1fbded',
+                800: '#6ad3f3',
+                900: '#b4e9f9'
+              },
+              poppy: {
+                DEFAULT: '#db3a34',
+                100: '#2e0908',
+                200: '#5c1310',
+                300: '#8a1c18',
+                400: '#b82520',
+                500: '#db3a34',
+                600: '#e2605c',
+                700: '#e98885',
+                800: '#f1b0ae',
+                900: '#f8d7d6'
+              },
+              sunglow: {
+                DEFAULT: '#ffc857',
+                100: '#442e00',
+                200: '#895b00',
+                300: '#cd8900',
+                400: '#ffb012',
+                500: '#ffc857',
+                600: '#ffd278',
+                700: '#ffdd9a',
+                800: '#ffe9bc',
+                900: '#fff4dd'
+              },
+              jet: {
+                DEFAULT: '#323031',
+                100: '#0a090a',
+                200: '#141313',
+                300: '#1e1c1d',
+                400: '#282627',
+                500: '#323031',
+                600: '#5c585a',
+                700: '#868183',
+                800: '#aeabac',
+                900: '#d7d5d6'
+              }
+            }
+          }
+        }
+      }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body>
+  <body class="bg-jet text-jet-900">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -19,7 +19,11 @@ export function BackToTopButton() {
   if (!visible) return null
 
   return (
-    <button className="back-to-top" onClick={scrollToTop} aria-label="Back to top">
+    <button
+      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-poppy text-sunglow shadow-lg flex items-center justify-center hover:bg-midnight_green hover:text-teal-100 transition"
+      onClick={scrollToTop}
+      aria-label="Back to top"
+    >
       ↑
     </button>
   )

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -6,12 +6,12 @@ export function Education() {
   return (
       <section
         id="education"
-        className="max-w-3xl mx-auto my-8 p-6 bg-[var(--honeydew)] rounded-lg shadow text-[var(--rich-black)]"
+        className="max-w-3xl mx-auto my-8 p-6 bg-midnight_green rounded-lg shadow border-l-4 border-poppy text-jet-900"
       >
-        <h2 className="text-2xl font-bold mb-4 text-center text-[var(--dark-purple)]">
+        <h2 className="text-2xl font-bold mb-4 text-center text-sunglow">
           {t('education.title')}
         </h2>
-        <ul className="list-disc pl-5 space-y-2">
+        <ul className="list-disc pl-5 space-y-2 marker:text-teal-400">
           {t('education.items').map((item, idx) => (
             <li key={idx}>{item}</li>
           ))}

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -5,10 +5,10 @@ export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="experience" className="max-w-3xl mx-auto my-16">
-      <h2 className="text-3xl font-bold text-center mb-8 text-[var(--dark-purple)]">{t('experience.title')}</h2>
+      <h2 className="text-3xl font-bold text-center mb-8 text-sunglow">{t('experience.title')}</h2>
       <div className="relative pl-10">
-        <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-[var(--naples-yellow)] to-[var(--dark-purple)]"></div>
-        <div className="relative mb-8 p-6 bg-[var(--honeydew)] rounded-xl shadow">
+        <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-poppy to-teal-500"></div>
+        <div className="relative mb-8 p-6 bg-midnight_green rounded-xl shadow text-jet-900">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <img
@@ -18,9 +18,9 @@ export function Experience() {
               />
               <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
             </div>
-            <span className="text-sm text-[var(--ash-gray)]">{t('experience.date')}</span>
+            <span className="text-sm text-jet-400">{t('experience.date')}</span>
           </div>
-          <ul className="list-disc pl-5 space-y-2 text-[var(--rich-black)]">
+          <ul className="list-disc pl-5 space-y-2 marker:text-sunglow">
             {t('experience.bullets').map((item, idx) => (
               <li key={idx}>{item}</li>
             ))}

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,7 +5,7 @@ export function Footer() {
   const { t } = useContext(LanguageContext)
   const lastUpdated = new Date().toLocaleDateString()
     return (
-      <footer className="text-center py-4 text-sm bg-[var(--rich-black)] text-[var(--honeydew)]">
+      <footer className="text-center py-4 text-sm bg-jet text-sunglow border-t border-midnight_green">
         {t('footer.name')} — {t('footer.updated')}: {lastUpdated}
       </footer>
     )

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -30,13 +30,13 @@ export function Navbar() {
 
   return (
     <nav className="fixed left-1/2 top-4 -translate-x-1/2 z-50">
-      <div className="flex items-center space-x-4 bg-[var(--honeydew)]/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg text-[var(--rich-black)]">
+      <div className="flex items-center space-x-4 bg-midnight_green/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg text-sunglow">
         {links.map((key) => (
           <a
             key={key}
             href={`#${key}`}
-            className={`px-3 py-2 rounded-md transition transform hover:scale-110 ${
-              active === key ? 'bg-[var(--naples-yellow)] text-[var(--rich-black)]' : ''
+            className={`px-3 py-2 rounded-md transition transform hover:scale-110 hover:text-teal-300 ${
+              active === key ? 'bg-poppy text-jet' : ''
             }`}
           >
             {t(`nav.${key}`)}
@@ -45,12 +45,12 @@ export function Navbar() {
         <div className="relative">
           <button
             onClick={() => setOpen(!open)}
-            className="w-12 h-12 rounded-full bg-[var(--naples-yellow)] text-[var(--rich-black)] shadow-lg flex items-center justify-center text-2xl hover:scale-110 transition"
+            className="w-12 h-12 rounded-full bg-poppy text-jet shadow-lg flex items-center justify-center text-2xl hover:scale-110 hover:bg-sunglow transition"
           >
             {lang === 'en' ? '🇺🇸' : '🇵🇱'}
           </button>
           {open && (
-            <ul className="absolute right-0 mt-2 bg-[var(--honeydew)] rounded-md shadow-lg overflow-hidden text-[var(--rich-black)]">
+            <ul className="absolute right-0 mt-2 bg-midnight_green rounded-md shadow-lg overflow-hidden text-sunglow">
               {langs.map((l) => (
                 <li key={l.code}>
                   <button
@@ -58,7 +58,7 @@ export function Navbar() {
                       setLang(l.code)
                       setOpen(false)
                     }}
-                    className="flex items-center space-x-2 px-3 py-2 hover:bg-[var(--naples-yellow)] w-full"
+                    className="flex items-center space-x-2 px-3 py-2 hover:bg-teal-700 w-full"
                   >
                     <span className="text-xl">{l.flag}</span>
                     <span>{l.label}</span>

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -12,21 +12,21 @@ export function PersonalInfo() {
   return (
     <section id="about" className="pt-24 max-w-5xl mx-auto my-8 grid gap-8 md:grid-cols-2 items-start">
       <div className="space-y-4 text-center md:text-left">
-        <h1 className="text-4xl font-bold">{t('header.name')}</h1>
-        <p className="text-xl text-[var(--ash-gray)]">{t('header.role')}</p>
+        <h1 className="text-4xl font-bold text-sunglow">{t('header.name')}</h1>
+        <p className="text-xl text-teal-300">{t('header.role')}</p>
 
         <h2 className="text-3xl font-bold mt-6">{t('about.title')}</h2>
         <p className="text-lg">{t('about.p1')}</p>
-        <p className="text-[var(--rich-black)]">{t('about.location')}</p>
+        <p className="text-jet-400">{t('about.location')}</p>
 
         <p className="space-x-2">
-          <a href="mailto:mpawlowski5467@gmail.com" className="text-[var(--dark-purple)] underline">
+          <a href="mailto:mpawlowski5467@gmail.com" className="text-midnight_green underline hover:text-teal-300">
             {t('about.email')}
           </a>
           <span aria-hidden>•</span>
           <a
             href="https://www.linkedin.com/in/mateusz-pawlowski-823849302/"
-            className="text-[var(--dark-purple)] underline"
+            className="text-midnight_green underline hover:text-teal-300"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -35,7 +35,7 @@ export function PersonalInfo() {
           <span aria-hidden>•</span>
           <a
             href="https://github.com/Mpawlowski5467"
-            className="text-[var(--dark-purple)] underline"
+            className="text-midnight_green underline hover:text-teal-300"
             target="_blank"
             rel="noopener noreferrer"
           >
@@ -45,10 +45,10 @@ export function PersonalInfo() {
       </div>
 
       <div className="mt-6 md:mt-0 text-center md:text-left">
-        <h3 className="text-2xl font-semibold text-[var(--dark-purple)]">{t('interests.title')}</h3>
+        <h3 className="text-2xl font-semibold text-poppy">{t('interests.title')}</h3>
         <ul className="flex flex-wrap justify-center md:justify-start gap-4 mt-2">
           {interestItems.map((item, idx) => (
-            <li key={item?.text ?? idx} className="flex items-center space-x-2">
+            <li key={item?.text ?? idx} className="flex items-center space-x-2 bg-midnight_green/60 text-sunglow px-2 py-1 rounded">
               {item?.icon && (
                 <span className="text-2xl" role="img" aria-label={item?.text ?? 'interest'}>
                   {item.icon}

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -5,24 +5,24 @@ export function Projects() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="projects" className="max-w-4xl mx-auto my-8">
-      <h2 className="text-3xl font-bold text-center mb-6 text-[var(--dark-purple)]">{t('projects.title')}</h2>
+      <h2 className="text-3xl font-bold text-center mb-6 text-sunglow">{t('projects.title')}</h2>
       <div className="grid gap-6 md:grid-cols-2">
         {t('projects.items').map((proj, idx) => (
           <div
             key={idx}
-            className="relative p-4 bg-[var(--honeydew)] rounded-lg shadow hover:shadow-lg transition-shadow text-[var(--rich-black)]"
+            className="relative p-4 bg-midnight_green border-2 border-teal-700 rounded-lg shadow hover:shadow-lg transition-shadow text-jet-900"
           >
             {proj.link && (
               <a
                 href={proj.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="absolute top-2 right-2 text-sm bg-[var(--naples-yellow)] text-[var(--rich-black)] px-2 py-1 rounded hover:bg-[var(--dark-purple)] hover:text-[var(--honeydew)]"
+                className="absolute top-2 right-2 text-sm bg-poppy text-jet px-2 py-1 rounded hover:bg-sunglow hover:text-midnight_green"
               >
                 {t('projects.github')}
               </a>
             )}
-            <h3 className="text-xl font-semibold mb-2">{proj.name}</h3>
+            <h3 className="text-xl font-semibold mb-2 text-poppy">{proj.name}</h3>
             <p>{proj.desc}</p>
           </div>
         ))}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -64,8 +64,8 @@ export function Skills() {
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
       }`}
     >
-      <h2 className="text-3xl font-bold text-center mb-8">{t('skills.title')}</h2>
-      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-[var(--honeydew)] overflow-hidden">
+      <h2 className="text-3xl font-bold text-center mb-8 text-poppy">{t('skills.title')}</h2>
+      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-jet border-4 border-teal-700 overflow-hidden">
         {skills.map((skill) => (
           <div key={skill.name} className="relative group w-16 h-16 flex items-center justify-center">
             {skill.icon ? (
@@ -86,7 +86,7 @@ export function Skills() {
                 {skill.emoji}
               </span>
             )}
-            <span className="absolute top-full mt-1 px-2 py-1 rounded bg-[var(--rich-black)] text-[var(--honeydew)] text-xs opacity-0 group-hover:opacity-100 whitespace-nowrap">
+            <span className="absolute top-full mt-1 px-2 py-1 rounded bg-poppy text-jet text-xs opacity-0 group-hover:opacity-100 whitespace-nowrap">
               {skill.name}
             </span>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,3 @@
-:root {
-  --dark-purple: #160c28ff;
-  --naples-yellow: #efcb68ff;
-  --honeydew: #e1efe6ff;
-  --ash-gray: #aeb7b3ff;
-  --rich-black: #000411ff;
-}
-
 html {
   scroll-behavior: smooth;
 }
@@ -14,26 +6,4 @@ body {
   margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
-  color: var(--rich-black);
-  background-color: var(--ash-gray);
-}
-
-header {
-  text-align: center;
-  padding: 2rem 1rem 1rem;
-  color: #fff;
-  background: linear-gradient(135deg, var(--dark-purple), var(--naples-yellow));
-}
-
-h1 {
-  font-size: 2.5rem;
-  margin-bottom: 0.5rem;
-}
-
-h2 {
-  color: var(--dark-purple);
-}
-
-a {
-  color: var(--dark-purple);
 }


### PR DESCRIPTION
## Summary
- set Jet as the base background and lighten default text
- restyle components to mix teal, midnight green, poppy, and sunglow for a balanced palette
- polish BackToTopButton hover and footer accents

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898d84b7a248329a3883da3955bacd2