### PR TITLE
Enhance portfolio color palette

### DIFF
--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -6,9 +6,9 @@ export function Education() {
   return (
       <section
         id="education"
-        className="max-w-3xl mx-auto my-8 p-6 bg-teal-900 rounded-lg shadow text-jet-100"
+        className="max-w-3xl mx-auto my-8 p-6 bg-sunglow rounded-lg shadow text-jet"
       >
-        <h2 className="text-2xl font-bold mb-4 text-center text-midnight_green">
+        <h2 className="text-2xl font-bold mb-4 text-center text-poppy">
           {t('education.title')}
         </h2>
         <ul className="list-disc pl-5 space-y-2">

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -5,10 +5,10 @@ export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="experience" className="max-w-3xl mx-auto my-16">
-      <h2 className="text-3xl font-bold text-center mb-8 text-midnight_green">{t('experience.title')}</h2>
+      <h2 className="text-3xl font-bold text-center mb-8 text-sunglow">{t('experience.title')}</h2>
       <div className="relative pl-10">
         <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-sunglow to-midnight_green"></div>
-        <div className="relative mb-8 p-6 bg-teal-900 rounded-xl shadow text-jet-100">
+        <div className="relative mb-8 p-6 bg-midnight_green rounded-xl shadow text-jet-900">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <img
@@ -18,7 +18,7 @@ export function Experience() {
               />
               <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
             </div>
-            <span className="text-sm text-jet-400">{t('experience.date')}</span>
+            <span className="text-sm text-sunglow">{t('experience.date')}</span>
           </div>
           <ul className="list-disc pl-5 space-y-2">
             {t('experience.bullets').map((item, idx) => (

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -30,7 +30,7 @@ export function Navbar() {
 
   return (
     <nav className="fixed left-1/2 top-4 -translate-x-1/2 z-50">
-      <div className="flex items-center space-x-4 bg-teal-900/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg text-jet-100">
+      <div className="flex items-center space-x-4 bg-midnight_green/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg text-teal-900">
         {links.map((key) => (
           <a
             key={key}
@@ -50,7 +50,7 @@ export function Navbar() {
             {lang === 'en' ? '🇺🇸' : '🇵🇱'}
           </button>
           {open && (
-            <ul className="absolute right-0 mt-2 bg-teal-900 rounded-md shadow-lg overflow-hidden text-jet-100">
+            <ul className="absolute right-0 mt-2 bg-midnight_green rounded-md shadow-lg overflow-hidden text-teal-900">
               {langs.map((l) => (
                 <li key={l.code}>
                   <button

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -10,7 +10,7 @@ export function Projects() {
         {t('projects.items').map((proj, idx) => (
           <div
             key={idx}
-            className="relative p-4 bg-teal-900 rounded-lg shadow hover:shadow-lg transition-shadow text-jet-100"
+            className="relative p-4 bg-poppy rounded-lg shadow hover:shadow-lg transition-shadow text-jet-100"
           >
             {proj.link && (
               <a
@@ -22,7 +22,7 @@ export function Projects() {
                 {t('projects.github')}
               </a>
             )}
-            <h3 className="text-xl font-semibold mb-2">{proj.name}</h3>
+            <h3 className="text-xl font-semibold mb-2 text-sunglow">{proj.name}</h3>
             <p>{proj.desc}</p>
           </div>
         ))}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -64,8 +64,8 @@ export function Skills() {
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
       }`}
     >
-      <h2 className="text-3xl font-bold text-center mb-8 text-midnight_green">{t('skills.title')}</h2>
-      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-teal-900 overflow-hidden">
+      <h2 className="text-3xl font-bold text-center mb-8 text-poppy">{t('skills.title')}</h2>
+      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-teal-900 border-4 border-poppy overflow-hidden">
         {skills.map((skill) => (
           <div key={skill.name} className="relative group w-16 h-16 flex items-center justify-center">
             {skill.icon ? (

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@ html {
   scroll-behavior: smooth;
 }
 
+:root {
+  --teal: #177e89ff;
+  --midnight-green: #084c61ff;
+  --poppy: #db3a34ff;
+  --sunglow: #ffc857ff;
+  --jet: #323031ff;
+}
+
 body {
   margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- define CSS variables for project color palette
- balance teal-heavy theme with midnight green, poppy, sunglow, and jet accents
- update section styles and navbar to use new colors

## Testing
- `npm test -- --run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6898dd6842d08329bc5cd0228b7e78cd