### PR TITLE
style: apply full color palette

### DIFF
--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -20,7 +20,7 @@ export function BackToTopButton() {
 
   return (
     <button
-      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-poppy text-teal-900 shadow-lg flex items-center justify-center hover:bg-poppy-600 transition"
+      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-teal text-sunglow border-2 border-sunglow shadow-lg flex items-center justify-center hover:bg-teal-600 transition"
       onClick={scrollToTop}
       aria-label="Back to top"
     >

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -65,7 +65,7 @@ export function Skills() {
       }`}
     >
       <h2 className="text-3xl font-bold text-center mb-8 text-poppy">{t('skills.title')}</h2>
-      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-teal-900 border-4 border-poppy overflow-hidden">
+      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-midnight_green border-4 border-sunglow overflow-hidden">
         {skills.map((skill) => (
           <div key={skill.name} className="relative group w-16 h-16 flex items-center justify-center">
             {skill.icon ? (

--- a/src/index.css
+++ b/src/index.css
@@ -14,4 +14,6 @@ body {
   margin: 0;
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
+  background-color: var(--jet);
+  color: var(--teal);
 }


### PR DESCRIPTION
## Summary
- set global jet background and teal text variables
- restyle skills circle with midnight green fill and sunglow border
- give back-to-top button a teal body and sunglow border to match theme

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e51235ac8329a6ac434ae51cfd62