### PR TITLE
Improve theme color usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="bg-jet text-teal-900">
+  <body class="bg-jet text-sunglow-900">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/index.css
+++ b/src/index.css
@@ -15,5 +15,44 @@ body {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   background-color: var(--jet);
+  color: var(--sunglow);
+}
+
+*,
+*::before,
+*::after {
+  border-color: var(--sunglow);
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  color: var(--poppy);
+}
+
+a {
   color: var(--teal);
+}
+
+a:hover,
+a:focus {
+  color: var(--poppy);
+}
+
+button,
+input[type='button'],
+input[type='submit'] {
+  background-color: var(--midnight-green);
+  color: var(--sunglow);
+  border: 1px solid var(--sunglow);
+}
+
+button:hover,
+input[type='button']:hover,
+input[type='submit']:hover {
+  background-color: var(--poppy);
+  color: var(--jet);
 }


### PR DESCRIPTION
## Summary
- switch base text to sunglow for better contrast
- apply sunglow borders and distribute palette to headings, links, and buttons
- update body class to match revised theme

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ea0d450083298f6b16a13b52afa1