### PR TITLE
style: apply full color theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
-  <body class="bg-jet text-teal-900">
+  <body class="bg-jet">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/src/index.css
+++ b/src/index.css
@@ -15,5 +15,42 @@ body {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   background-color: var(--jet);
-  color: var(--teal);
+  color: var(--sunglow);
+}
+
+*, *::before, *::after {
+  border-color: var(--sunglow);
+}
+
+h1, h2, h3, h4, h5, h6 {
+  color: color-mix(in srgb, var(--poppy), white 70%);
+}
+
+a {
+  color: var(--jet);
+  background-color: var(--teal);
+  text-decoration-color: var(--sunglow);
+}
+
+a:hover,
+a:focus {
+  background-color: var(--midnight-green);
+  color: var(--sunglow);
+}
+
+button {
+  background-color: var(--midnight-green);
+  color: var(--sunglow);
+  border: 2px solid var(--sunglow);
+}
+
+button:hover,
+button:focus {
+  background-color: var(--teal);
+  color: var(--jet);
+}
+
+::selection {
+  background: color-mix(in srgb, var(--poppy), white 70%);
+  color: var(--jet);
 }


### PR DESCRIPTION
## Summary
- switch base text to sunglow and apply sunflow borders
- add styles for headings, links and buttons that use all theme colors
- drop green text class from body

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ea0d450083298f6b16a13b52afa1