### PR TITLE
feat: refresh layout and add live clocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,12 +9,15 @@
       tailwind.config = {
         theme: {
             extend: {
-              colors: {
+          colors: {
                 primary: '#339989',
                 secondary: '#7de2d1',
+                accent: '#7de2d1',
                 background: '#131515',
                 surface: '#2b2c28',
-                text: '#fffafb'
+                text: '#fffafb',
+                neutral: '#fffafb',
+                sunflow: '#f6ae2d'
               }
             }
           }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,7 @@ import { Education } from './components/Education.jsx'
 import { Skills } from './components/Skills.jsx'
 import { BackToTopButton } from './components/BackToTopButton.jsx'
 import { Footer } from './components/Footer.jsx'
-import { Navbar } from './components/Navbar.jsx'
+import { TopRow } from './components/TopRow.jsx'
 import { LanguageContext } from './context/LanguageContext.jsx'
 import { translations } from './i18n.js'
 
@@ -17,7 +17,7 @@ export function App() {
 
   return (
     <LanguageContext.Provider value={{ lang, setLang, t }}>
-      <Navbar />
+      <TopRow />
       <PersonalInfo />
       <Experience />
       <Projects />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,9 +4,43 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Footer() {
   const { t } = useContext(LanguageContext)
   const lastUpdated = new Date().toLocaleDateString()
-      return (
-        <footer className="text-center py-4 text-sm bg-surface text-secondary">
-          {t('footer.name')} — {t('footer.updated')}: {lastUpdated}
-        </footer>
-      )
-    }
+  return (
+    <footer className="site-footer">
+      <div className="social-links">
+        <a
+          href="https://github.com/Mpawlowski5467"
+          className="icon-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.38 7.86 10.89.58.11.79-.25.79-.56v-2c-3.2.69-3.88-1.54-3.88-1.54-.53-1.35-1.3-1.71-1.3-1.71-1.06-.73.08-.72.08-.72 1.17.08 1.78 1.2 1.78 1.2 1.04 1.77 2.72 1.26 3.38.96.11-.75.41-1.26.75-1.55-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.18 1.83 1.18 3.09 0 4.43-2.69 5.41-5.26 5.69.42.36.8 1.07.8 2.16v3.2c0 .31.21.68.8.56A10.51 10.51 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z" />
+          </svg>
+          <span>{t('about.github')}</span>
+        </a>
+        <a
+          href="https://www.linkedin.com/in/mateusz-pawlowski-823849302/"
+          className="icon-link"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4.98 3.5C4.98 4.88 3.86 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4zM8.5 8h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.7c0-1.84-.03-4.2-2.56-4.2-2.56 0-2.95 2-2.95 4.1V24h-4z" />
+          </svg>
+          <span>{t('about.linkText')}</span>
+        </a>
+        <a href="mailto:mpawlowski5467@gmail.com" className="icon-link">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M2 4h20v16H2z" fill="none" />
+            <path d="M2 4h20v16H2z" stroke="currentColor" strokeWidth="2" />
+            <path d="m22 4-10 7L2 4" fill="none" stroke="currentColor" strokeWidth="2" />
+          </svg>
+          <span>{t('about.email')}</span>
+        </a>
+      </div>
+      <div className="foot-note">
+        {t('footer.name')} — {t('footer.updated')}: {lastUpdated}
+      </div>
+    </footer>
+  )
+}

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -29,28 +29,26 @@ export function Navbar() {
   const links = ['about', 'experience', 'projects', 'education', 'skills']
 
   return (
-      <nav className="fixed left-1/2 top-4 -translate-x-1/2 z-50">
-        <div className="flex items-center space-x-4 bg-primary/80 backdrop-blur px-6 py-3 rounded-2xl shadow-lg text-background">
+    <nav className="navbar">
+      <div className="nav-inner">
         {links.map((key) => (
           <a
             key={key}
             href={`#${key}`}
-              className={`px-3 py-2 rounded-md transition transform hover:scale-110 ${
-                active === key ? 'bg-secondary text-background' : ''
-              }`}
+            className={`nav-link ${active === key ? 'active' : ''}`}
           >
             {t(`nav.${key}`)}
           </a>
         ))}
         <div className="relative">
-            <button
-              onClick={() => setOpen(!open)}
-              className="w-12 h-12 rounded-full bg-secondary text-background shadow-lg flex items-center justify-center text-2xl hover:scale-110 transition"
-            >
+          <button
+            onClick={() => setOpen(!open)}
+            className="lang-btn"
+          >
             {lang === 'en' ? '🇺🇸' : '🇵🇱'}
           </button>
-            {open && (
-              <ul className="absolute right-0 mt-2 bg-primary rounded-md shadow-lg overflow-hidden text-background">
+          {open && (
+            <ul className="lang-menu">
               {langs.map((l) => (
                 <li key={l.code}>
                   <button
@@ -58,7 +56,7 @@ export function Navbar() {
                       setLang(l.code)
                       setOpen(false)
                     }}
-                      className="flex items-center space-x-2 px-3 py-2 hover:bg-secondary w-full"
+                    className="lang-option"
                   >
                     <span className="text-xl">{l.flag}</span>
                     <span>{l.label}</span>

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -19,27 +19,36 @@ export function PersonalInfo() {
         <p className="text-lg">{t('about.p1')}</p>
           <p className="text-secondary">{t('about.location')}</p>
 
-        <p className="space-x-2">
-            <a href="mailto:mpawlowski5467@gmail.com" className="text-primary underline">
-            {t('about.email')}
+        <p className="contact-links">
+          <a href="mailto:mpawlowski5467@gmail.com" className="icon-link">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M2 4h20v16H2z" fill="none" />
+              <path d="M2 4h20v16H2z" stroke="currentColor" strokeWidth="2" />
+              <path d="m22 4-10 7L2 4" fill="none" stroke="currentColor" strokeWidth="2" />
+            </svg>
+            <span>{t('about.email')}</span>
           </a>
-          <span aria-hidden>•</span>
           <a
             href="https://www.linkedin.com/in/mateusz-pawlowski-823849302/"
-              className="text-primary underline"
+            className="icon-link"
             target="_blank"
             rel="noopener noreferrer"
           >
-            {t('about.linkText')}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M4.98 3.5C4.98 4.88 3.86 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4zM8.5 8h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.7c0-1.84-.03-4.2-2.56-4.2-2.56 0-2.95 2-2.95 4.1V24h-4z" />
+            </svg>
+            <span>{t('about.linkText')}</span>
           </a>
-          <span aria-hidden>•</span>
           <a
             href="https://github.com/Mpawlowski5467"
-              className="text-primary underline"
+            className="icon-link"
             target="_blank"
             rel="noopener noreferrer"
           >
-            {t('about.github')}
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 .5C5.73.5.5 5.73.5 12c0 5.08 3.29 9.38 7.86 10.89.58.11.79-.25.79-.56v-2c-3.2.69-3.88-1.54-3.88-1.54-.53-1.35-1.3-1.71-1.3-1.71-1.06-.73.08-.72.08-.72 1.17.08 1.78 1.2 1.78 1.2 1.04 1.77 2.72 1.26 3.38.96.11-.75.41-1.26.75-1.55-2.55-.29-5.23-1.28-5.23-5.7 0-1.26.45-2.28 1.19-3.09-.12-.29-.52-1.46.11-3.05 0 0 .97-.31 3.18 1.18a11.1 11.1 0 0 1 5.8 0c2.2-1.49 3.17-1.18 3.17-1.18.63 1.59.23 2.76.11 3.05.74.81 1.18 1.83 1.18 3.09 0 4.43-2.69 5.41-5.26 5.69.42.36.8 1.07.8 2.16v3.2c0 .31.21.68.8.56A10.51 10.51 0 0 0 23.5 12C23.5 5.73 18.27.5 12 .5z" />
+            </svg>
+            <span>{t('about.github')}</span>
           </a>
         </p>
       </div>

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -4,26 +4,23 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 export function Projects() {
   const { t } = useContext(LanguageContext)
   return (
-    <section id="projects" className="max-w-4xl mx-auto my-8">
-        <h2 className="text-3xl font-bold text-center mb-6 text-primary">{t('projects.title')}</h2>
-      <div className="grid gap-6 md:grid-cols-2">
+    <section id="projects" className="projects-section">
+      <h2 className="section-title">{t('projects.title')}</h2>
+      <div className="projects-grid">
         {t('projects.items').map((proj, idx) => (
-          <div
-            key={idx}
-              className="relative p-4 bg-primary rounded-lg shadow hover:shadow-lg transition-shadow text-background"
-          >
+          <div key={idx} className="project-card" tabIndex="0">
             {proj.link && (
               <a
                 href={proj.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                  className="absolute top-2 right-2 text-sm bg-secondary text-background px-2 py-1 rounded hover:bg-primary hover:text-background"
+                className="project-link"
               >
                 {t('projects.github')}
               </a>
             )}
-              <h3 className="text-xl font-semibold mb-2 text-secondary">{proj.name}</h3>
-            <p>{proj.desc}</p>
+            <h3 className="project-title">{proj.name}</h3>
+            <p className="project-desc">{proj.desc}</p>
           </div>
         ))}
       </div>

--- a/src/components/TopRow.jsx
+++ b/src/components/TopRow.jsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { Navbar } from './Navbar.jsx'
+
+const zones = [
+  { city: 'Chicago', tz: 'America/Chicago' },
+  { city: 'Krak\u00f3w', tz: 'Europe/Warsaw' },
+  { city: 'Beijing', tz: 'Asia/Shanghai' },
+  { city: 'Sydney', tz: 'Australia/Sydney' }
+]
+
+function formatTime(zone) {
+  return new Intl.DateTimeFormat('en-GB', {
+    timeZone: zone,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false
+  }).format(new Date())
+}
+
+export function TopRow() {
+  const [times, setTimes] = useState(() => zones.map((z) => ({ ...z, time: formatTime(z.tz) })))
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setTimes(zones.map((z) => ({ ...z, time: formatTime(z.tz) })))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  return (
+    <header className="top-row">
+      {times.slice(0, 2).map((tz) => (
+        <Clock key={tz.tz} city={tz.city} time={tz.time} />
+      ))}
+      <Navbar />
+      {times.slice(2).map((tz) => (
+        <Clock key={tz.tz} city={tz.city} time={tz.time} />
+      ))}
+    </header>
+  )
+}
+
+function Clock({ city, time }) {
+  return (
+    <div className="clock" aria-label={city}>
+      <span className="clock-label">{city}</span>
+      <span className="clock-time">{time}</span>
+    </div>
+  )
+}
+

--- a/src/index.css
+++ b/src/index.css
@@ -3,11 +3,20 @@ html {
 }
 
 :root {
-  --primary: #339989ff;
-  --secondary: #7de2d1ff;
-  --background: #131515ff;
-  --surface: #2b2c28ff;
-  --text: #fffafbff;
+  --primary: #339989;
+  --accent: #7de2d1;
+  --neutral: #fffafb;
+  --background: #131515;
+  --surface: #2b2c28;
+  --sunflow: #f6ae2d;
+  --sunflow-rgb: 246, 174, 45;
+
+  --radius-sm: 10px;
+  --radius-md: 12px;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --max-width: 1200px;
 }
 
 body {
@@ -15,7 +24,15 @@ body {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.6;
   background-color: var(--background);
-  color: var(--text);
+  color: var(--neutral);
+  padding-top: 4rem;
+  overflow-x: hidden;
+}
+
+#root {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--space-md);
 }
 
 
@@ -29,48 +46,290 @@ h6 {
 }
 
 a {
-  color: var(--secondary);
+  color: var(--accent);
   text-decoration: none;
-}
-
-a:hover {
-  color: var(--primary);
-}
-
-button {
-  background-color: var(--primary);
-  color: var(--background);
-  border: 1px solid var(--secondary);
-  cursor: pointer;
-}
-
-button:hover {
-  background-color: var(--secondary);
-  color: var(--background);
-}
-
-*,
-*::before,
-*::after {
-  border-color: var(--secondary);
 }
 
 a:hover,
 a:focus {
   color: var(--primary);
+  text-decoration: underline;
 }
 
 button,
 input[type='button'],
 input[type='submit'] {
   background-color: var(--primary);
-  color: var(--text);
-  border: 1px solid var(--secondary);
+  color: var(--background);
+  border: 1px solid var(--sunflow);
+  cursor: pointer;
 }
 
 button:hover,
+button:focus,
 input[type='button']:hover,
-input[type='submit']:hover {
-  background-color: var(--secondary);
+input[type='button']:focus,
+input[type='submit']:hover,
+input[type='submit']:focus {
+  background-color: var(--accent);
   color: var(--background);
+}
+
+*,
+*::before,
+*::after {
+  border-color: var(--sunflow);
+}
+
+/* Utility classes */
+.section-title {
+  text-align: center;
+  margin-bottom: var(--space-lg);
+  font-size: 2rem;
+}
+
+.projects-section {
+  padding: var(--space-lg) 0;
+}
+
+.projects-grid {
+  display: grid;
+  gap: var(--space-lg);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 480px) {
+  .projects-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 900px) {
+  .projects-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.project-card {
+  background-color: var(--surface);
+  border: 1px solid rgba(var(--sunflow-rgb), 0.5);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  position: relative;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.project-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  border-color: rgba(var(--sunflow-rgb), 0.9);
+}
+
+.project-card:focus-within {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.project-title {
+  color: var(--primary);
+  margin-top: 0;
+  margin-bottom: var(--space-sm);
+}
+
+.project-link {
+  position: absolute;
+  top: var(--space-sm);
+  right: var(--space-sm);
+  background-color: var(--accent);
+  color: var(--background);
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+}
+
+.project-link:hover,
+.project-link:focus {
+  background-color: var(--primary);
+}
+
+.contact-links,
+.social-links {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-top: var(--space-sm);
+}
+
+.icon-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  color: var(--accent);
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.icon-link svg {
+  width: 1rem;
+  height: 1rem;
+  fill: currentColor;
+}
+
+.icon-link:hover,
+.icon-link:focus {
+  color: var(--primary);
+  text-decoration: underline;
+  transform: scale(1.05);
+}
+
+.site-footer {
+  text-align: center;
+  background-color: var(--surface);
+  padding: var(--space-lg) 0;
+  color: var(--neutral);
+  margin-top: var(--space-lg);
+}
+
+.foot-note {
+  margin-top: var(--space-sm);
+  font-size: 0.875rem;
+  color: var(--accent);
+}
+
+.top-row {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--background);
+  z-index: 50;
+  flex-wrap: wrap;
+}
+
+.navbar {
+  display: flex;
+  order: 3;
+}
+
+.nav-inner {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  background-color: var(--primary);
+  color: var(--background);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-md);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+}
+
+.nav-link {
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  color: inherit;
+}
+
+.nav-link:hover,
+.nav-link:focus {
+  background-color: var(--accent);
+  color: var(--background);
+  text-decoration: underline;
+}
+
+.nav-link.active {
+  background-color: var(--accent);
+  color: var(--background);
+}
+
+.lang-btn {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  background-color: var(--accent);
+  color: var(--background);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lang-menu {
+  position: absolute;
+  right: 0;
+  margin-top: var(--space-sm);
+  background-color: var(--primary);
+  border: 1px solid var(--sunflow);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  overflow: hidden;
+}
+
+.lang-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  width: 100%;
+  color: inherit;
+}
+
+.lang-option:hover,
+.lang-option:focus {
+  background-color: var(--accent);
+  color: var(--background);
+}
+
+.clock {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--neutral);
+  font-family: monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+.clock-label {
+  font-size: 0.75rem;
+  color: var(--accent);
+}
+
+.clock-time {
+  color: var(--neutral);
+}
+
+@media (max-width: 600px) {
+  .navbar {
+    flex-basis: 100%;
+    order: 5;
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project-card,
+  .icon-link,
+  .nav-link,
+  .lang-btn {
+    transition: none;
+  }
+  .project-card:hover,
+  .icon-link:hover,
+  .nav-link:hover,
+  .lang-btn:hover {
+    transform: none;
+  }
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='200' height='200' fill='%23ffffff'%3E%3Ctext x='0' y='20' font-size='16'%3Econst%3C/text%3E%3Ctext x='0' y='60' font-size='16'%3Efunction%3C/text%3E%3Ctext x='0' y='100' font-size='16'%3E&lt;/&gt;%3C/text%3E%3C/svg%3E");
+  background-repeat: repeat;
+  opacity: 0.06;
+  pointer-events: none;
+  z-index: -1;
 }


### PR DESCRIPTION
## Summary
- polish theme with a centralized color palette and sunflow borders
- add responsive project cards and social icon links
- introduce top-row live clocks for multiple time zones

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f468e1b48329ac455d6fbe3838d9