### PR TITLE
feat: reinstate blurred navbar with fixed clocks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,8 @@ import { Education } from './components/Education.jsx'
 import { Skills } from './components/Skills.jsx'
 import { BackToTopButton } from './components/BackToTopButton.jsx'
 import { Footer } from './components/Footer.jsx'
-import { TopRow } from './components/TopRow.jsx'
+import { ClockBar } from './components/ClockBar.jsx'
+import { Navbar } from './components/Navbar.jsx'
 import { LanguageContext } from './context/LanguageContext.jsx'
 import { translations } from './i18n.js'
 
@@ -17,7 +18,8 @@ export function App() {
 
   return (
     <LanguageContext.Provider value={{ lang, setLang, t }}>
-      <TopRow />
+      <ClockBar />
+      <Navbar />
       <PersonalInfo />
       <Experience />
       <Projects />

--- a/src/components/ClockBar.jsx
+++ b/src/components/ClockBar.jsx
@@ -1,9 +1,8 @@
 import { useEffect, useState } from 'react'
-import { Navbar } from './Navbar.jsx'
 
 const zones = [
   { city: 'Chicago', tz: 'America/Chicago' },
-  { city: 'Krak\u00f3w', tz: 'Europe/Warsaw' },
+  { city: 'Kraków', tz: 'Europe/Warsaw' },
   { city: 'Beijing', tz: 'Asia/Shanghai' },
   { city: 'Sydney', tz: 'Australia/Sydney' }
 ]
@@ -18,8 +17,10 @@ function formatTime(zone) {
   }).format(new Date())
 }
 
-export function TopRow() {
-  const [times, setTimes] = useState(() => zones.map((z) => ({ ...z, time: formatTime(z.tz) })))
+export function ClockBar() {
+  const [times, setTimes] = useState(() =>
+    zones.map((z) => ({ ...z, time: formatTime(z.tz) }))
+  )
 
   useEffect(() => {
     const id = setInterval(() => {
@@ -29,15 +30,18 @@ export function TopRow() {
   }, [])
 
   return (
-    <header className="top-row">
-      {times.slice(0, 2).map((tz) => (
-        <Clock key={tz.tz} city={tz.city} time={tz.time} />
-      ))}
-      <Navbar />
-      {times.slice(2).map((tz) => (
-        <Clock key={tz.tz} city={tz.city} time={tz.time} />
-      ))}
-    </header>
+    <div className="clock-bar" role="group" aria-label="World clocks">
+      <div className="clock-group">
+        {times.slice(0, 2).map((tz) => (
+          <Clock key={tz.tz} city={tz.city} time={tz.time} />
+        ))}
+      </div>
+      <div className="clock-group">
+        {times.slice(2).map((tz) => (
+          <Clock key={tz.tz} city={tz.city} time={tz.time} />
+        ))}
+      </div>
+    </div>
   )
 }
 

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -5,6 +5,7 @@ export function Navbar() {
   const { lang, setLang, t } = useContext(LanguageContext)
   const [active, setActive] = useState('about')
   const [open, setOpen] = useState(false)
+  const [scrolled, setScrolled] = useState(false)
 
   useEffect(() => {
     if (typeof window === 'undefined' || !('IntersectionObserver' in window)) return
@@ -28,8 +29,24 @@ export function Navbar() {
 
   const links = ['about', 'experience', 'projects', 'education', 'skills']
 
+  useEffect(() => {
+    let ticking = false
+    const handleScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          setScrolled(window.scrollY > 0)
+          ticking = false
+        })
+        ticking = true
+      }
+    }
+    window.addEventListener('scroll', handleScroll)
+    handleScroll()
+    return () => window.removeEventListener('scroll', handleScroll)
+  }, [])
+
   return (
-    <nav className="navbar">
+    <nav className={`navbar ${scrolled ? 'scrolled' : ''}`}>
       <div className="nav-inner">
         {links.map((key) => (
           <a

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,10 @@ html {
   --surface: #2b2c28;
   --sunflow: #f6ae2d;
   --sunflow-rgb: 246, 174, 45;
+  --background-rgb: 19, 21, 21;
+
+  --clock-bar-height: 2.5rem;
+  --navbar-height: 3rem;
 
   --radius-sm: 10px;
   --radius-md: 12px;
@@ -25,7 +29,7 @@ body {
   line-height: 1.6;
   background-color: var(--background);
   color: var(--neutral);
-  padding-top: 4rem;
+  padding-top: calc(var(--clock-bar-height) + var(--navbar-height));
   overflow-x: hidden;
 }
 
@@ -196,35 +200,52 @@ input[type='submit']:focus {
   color: var(--accent);
 }
 
-.top-row {
+
+.clock-bar {
   position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: var(--space-md);
   padding: var(--space-sm) var(--space-md);
   background-color: var(--background);
   z-index: 50;
   flex-wrap: wrap;
+  border-bottom: 1px solid var(--sunflow);
+}
+
+.clock-group {
+  display: flex;
+  gap: var(--space-md);
 }
 
 .navbar {
+  position: sticky;
+  top: var(--clock-bar-height);
+  z-index: 40;
   display: flex;
-  order: 3;
+  justify-content: center;
+  align-items: center;
+  height: var(--navbar-height);
+  color: var(--neutral);
+  background-color: transparent;
+  transition: background-color 0.3s ease, backdrop-filter 0.3s ease;
+}
+
+.navbar.scrolled {
+  background-color: rgba(var(--background-rgb), 0.7);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--sunflow);
 }
 
 .nav-inner {
   display: flex;
   align-items: center;
   gap: var(--space-md);
-  background-color: var(--primary);
-  color: var(--background);
   padding: var(--space-sm) var(--space-md);
-  border-radius: var(--radius-md);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
 }
 
 .nav-link {
@@ -301,9 +322,12 @@ input[type='submit']:focus {
 }
 
 @media (max-width: 600px) {
-  .navbar {
-    flex-basis: 100%;
-    order: 5;
+  .clock-bar {
+    flex-direction: column;
+    align-items: center;
+  }
+  .clock-group {
+    width: 100%;
     justify-content: center;
   }
 }
@@ -312,7 +336,8 @@ input[type='submit']:focus {
   .project-card,
   .icon-link,
   .nav-link,
-  .lang-btn {
+  .lang-btn,
+  .navbar {
     transition: none;
   }
   .project-card:hover,


### PR DESCRIPTION
## Summary
- restore scroll-aware navbar blur and stick it under a new clock bar
- add fixed world-clock bar showing Chicago, Kraków, Beijing and Sydney
- adjust styles and spacing to accommodate clock bar and sticky nav

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898f99cedd483298b280ca5d8706476