### PR TITLE
refactor: apply new color palette

### DIFF
--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -20,7 +20,7 @@ export function BackToTopButton() {
 
   return (
     <button
-      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-plum text-dutch-white border-2 border-cambridge-blue shadow-lg flex items-center justify-center hover:bg-cambridge-blue hover:text-black transition focus:outline-none focus-visible:ring-2 ring-plum"
+      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-primary text-foreground border-2 border-neutral shadow-lg flex items-center justify-center hover:bg-secondary hover:text-foreground transition focus:outline-none focus-visible:ring-2 ring-primary"
       onClick={scrollToTop}
       aria-label="Back to top"
     >

--- a/src/components/ClockBar.jsx
+++ b/src/components/ClockBar.jsx
@@ -35,7 +35,7 @@ export function ClockBar() {
 
   return (
     // Slim bar fixed to the very top
-    <div className="fixed top-0 left-0 right-0 z-50 flex justify-between px-4 h-[var(--clock-bar-h)] bg-violet-jtc/90 text-dutch-white font-mono text-[0.65rem] sm:text-xs">
+    <div className="fixed top-0 left-0 right-0 z-50 flex justify-between px-4 h-[var(--clock-bar-h)] bg-secondary/90 text-foreground font-mono text-[0.65rem] sm:text-xs">
       {/* Left group: first two time zones */}
       <div className="flex gap-4 items-center">
         {times.slice(0, 2).map((tz) => (
@@ -55,7 +55,7 @@ export function ClockBar() {
 function Clock({ city, time }) {
   return (
     <div className="flex flex-col items-center" aria-label={city}>
-      <span className="text-cambridge-blue">{city}</span>
+      <span className="text-neutral">{city}</span>
       <span>{time}</span>
     </div>
   )

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -6,9 +6,9 @@ export function Education() {
   return (
     <section
       id="education"
-      className="max-w-3xl mx-auto my-8 p-6 bg-cambridge-blue text-black rounded-lg shadow"
+      className="max-w-3xl mx-auto my-8 p-6 bg-secondary text-foreground rounded-lg shadow"
     >
-      <h2 className="text-2xl font-bold mb-4 text-center text-plum">
+      <h2 className="text-2xl font-bold mb-4 text-center text-primary">
         {t('education.title')}
       </h2>
       <ul className="list-disc pl-5 space-y-2">

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -5,11 +5,11 @@ export function Experience() {
   const { t } = useContext(LanguageContext)
   return (
     <section id="experience" className="max-w-3xl mx-auto my-16 px-4">
-      <h2 className="text-3xl font-bold text-center mb-8 text-plum">{t('experience.title')}</h2>
+      <h2 className="text-3xl font-bold text-center mb-8 text-primary">{t('experience.title')}</h2>
       <div className="relative pl-10">
         {/* Vertical timeline line */}
-        <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-plum to-violet-jtc" />
-        <div className="relative mb-8 p-6 bg-cambridge-blue text-black rounded-xl shadow">
+        <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-primary to-secondary" />
+        <div className="relative mb-8 p-6 bg-secondary text-foreground rounded-xl shadow">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <img
@@ -19,7 +19,7 @@ export function Experience() {
               />
               <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
             </div>
-            <span className="text-sm text-violet-jtc">{t('experience.date')}</span>
+            <span className="text-sm text-neutral">{t('experience.date')}</span>
           </div>
           <ul className="list-disc pl-5 space-y-2">
             {t('experience.bullets').map((item, idx) => (

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,7 +7,7 @@ function SocialLink({ href, label, children }) {
       href={href}
       aria-label={label}
       title={label}
-      className="w-6 h-6 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 ring-plum rounded"
+      className="w-6 h-6 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 ring-primary rounded"
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -37,7 +37,7 @@ export function Footer() {
 
   return (
     // Fixed footer anchored to bottom; padding is handled by global CSS
-    <footer className="fixed bottom-0 left-0 right-0 z-30 h-[var(--footer-h)] bg-violet-jtc/90 text-dutch-white flex items-center justify-center gap-6 text-sm">
+    <footer className="fixed bottom-0 left-0 right-0 z-30 h-[var(--footer-h)] bg-secondary/90 text-foreground flex items-center justify-center gap-6 text-sm">
       <SocialLink href="https://github.com/Mpawlowski5467" label={t('about.github')}>
         {gh}
       </SocialLink>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -39,7 +39,7 @@ export function Navbar() {
     >
       <nav
         aria-label="Primary"
-        className="flex gap-4 rounded-3xl bg-dutch-white/40 backdrop-blur-md shadow-lg border border-white/20 px-4 py-2"
+        className="flex gap-4 rounded-3xl bg-foreground/40 backdrop-blur-md shadow-lg border border-white/20 px-4 py-2"
       >
         {items.map((item, i) => (
           <a
@@ -50,7 +50,7 @@ export function Navbar() {
             aria-label={item.label}
             // Scale via inline style so neighbours react to cursor proximity
             style={{ transform: `scale(${scaleFor(i)})` }}
-            className="w-8 h-8 flex items-center justify-center text-2xl transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 ring-plum rounded-md"
+            className="w-8 h-8 flex items-center justify-center text-2xl transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 ring-primary rounded-md"
             onFocus={(e) => {
               const rect = e.currentTarget.getBoundingClientRect()
               setMouseX(rect.left + rect.width / 2)

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -7,7 +7,7 @@ function IconLink({ href, label, children }) {
       href={href}
       aria-label={label}
       title={label}
-      className="w-8 h-8 flex items-center justify-center rounded hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 ring-plum"
+      className="w-8 h-8 flex items-center justify-center rounded hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 ring-primary"
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -25,12 +25,12 @@ export function PersonalInfo() {
   return (
     <section id="about" className="max-w-5xl mx-auto my-8 grid gap-8 px-4 md:grid-cols-2 items-start">
       <div className="space-y-4 text-center md:text-left">
-        <h1 className="text-4xl font-bold text-plum">{t('header.name')}</h1>
-        <p className="text-xl text-cambridge-blue">{t('header.role')}</p>
+        <h1 className="text-4xl font-bold text-primary">{t('header.name')}</h1>
+        <p className="text-xl text-secondary">{t('header.role')}</p>
 
-        <h2 className="text-3xl font-bold mt-6 text-plum">{t('about.title')}</h2>
+        <h2 className="text-3xl font-bold mt-6 text-primary">{t('about.title')}</h2>
         <p className="text-lg max-w-prose mx-auto md:mx-0">{t('about.p1')}</p>
-        <p className="text-cambridge-blue">{t('about.location')}</p>
+        <p className="text-neutral">{t('about.location')}</p>
 
         {/* Contact icons with accessible labels */}
         <div className="flex gap-4 justify-center md:justify-start mt-4">
@@ -55,7 +55,7 @@ export function PersonalInfo() {
 
       {/* Interests list */}
       <div className="mt-6 md:mt-0 text-center md:text-left">
-        <h3 className="text-2xl font-semibold text-plum">{t('interests.title')}</h3>
+        <h3 className="text-2xl font-semibold text-primary">{t('interests.title')}</h3>
         <ul className="flex flex-wrap justify-center md:justify-start gap-4 mt-2">
           {interestItems.map((item, idx) => (
             <li key={item?.text ?? idx} className="flex items-center space-x-2">

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -3,25 +3,24 @@ import { LanguageContext } from '../context/LanguageContext.jsx'
 
 export function Projects() {
   const { t } = useContext(LanguageContext)
-  const borderColors = ['border-plum', 'border-violet-jtc', 'border-cambridge-blue']
 
   return (
     <section id="projects" className="max-w-5xl mx-auto my-8 px-4">
-      <h2 className="text-3xl font-bold text-plum text-center mb-6">{t('projects.title')}</h2>
+      <h2 className="text-3xl font-bold text-primary text-center mb-6">{t('projects.title')}</h2>
       {/* Responsive grid: 1 col on mobile, 2 on small screens, 3 on large */}
       <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
         {t('projects.items').map((proj, idx) => (
           <div
             key={idx}
             tabIndex="0"
-            className={`p-4 rounded-lg bg-violet-jtc/20 text-dutch-white border ${borderColors[idx % borderColors.length]} shadow`}
+            className="p-4 rounded-lg bg-background text-foreground border border-neutral shadow"
           >
             {proj.link && (
               <a
                 href={proj.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-sm text-cambridge-blue underline focus:outline-none focus-visible:ring-2 ring-plum rounded"
+                className="text-sm text-secondary underline focus:outline-none focus-visible:ring-2 ring-primary rounded"
               >
                 {t('projects.github')}
               </a>

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -63,9 +63,9 @@ export function Skills() {
         visible ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
       }`}
     >
-      <h2 className="text-3xl font-bold text-center mb-8 text-plum">{t('skills.title')}</h2>
+      <h2 className="text-3xl font-bold text-center mb-8 text-primary">{t('skills.title')}</h2>
       {/* Circular cloud of skill icons */}
-      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-plum border-4 border-cambridge-blue overflow-hidden">
+      <div className="relative w-[28rem] h-[28rem] mx-auto flex flex-wrap content-center justify-center gap-4 rounded-full bg-primary border-4 border-neutral overflow-hidden">
         {skills.map((skill) => (
           <div key={skill.name} className="relative group w-16 h-16 flex items-center justify-center">
             {skill.icon ? (
@@ -86,7 +86,7 @@ export function Skills() {
                 {skill.emoji}
               </span>
             )}
-            <span className="absolute top-full mt-1 px-2 py-1 rounded bg-violet-jtc text-dutch-white text-xs opacity-0 group-hover:opacity-100 whitespace-nowrap">
+            <span className="absolute top-full mt-1 px-2 py-1 rounded bg-secondary text-foreground text-xs opacity-0 group-hover:opacity-100 whitespace-nowrap">
               {skill.name}
             </span>
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -8,11 +8,20 @@
   - --footer-h    : footer height
 */
 :root {
-  --dutch-white: #dccca3ff;
-  --plum: #824c71ff;
-  --violet-jtc: #4a2545ff;
-  --black: #000001ff;
-  --cambridge-blue: #90aa86ff;
+  /* Primary brand color – used for main accents, buttons, and links */
+  --primary: #62929eff; /* Blue Munsell */
+
+  /* Secondary brand color – used for highlights, hover states, or minor accents */
+  --secondary: #546a7bff; /* Paynes Gray */
+
+  /* Background – used for main page backgrounds */
+  --background: #393d3fff; /* Onyx */
+
+  /* Foreground text – used for primary readable text on background */
+  --foreground: #fdfdffff; /* White */
+
+  /* Neutral – used for borders, dividers, and subtle text */
+  --neutral: #c6c5b9ff; /* Silver */
 
   /* Layout dimensions */
   --clock-bar-h: 1.75rem;
@@ -25,8 +34,8 @@ body {
   margin: 0;
   font-family: system-ui, sans-serif;
   line-height: 1.6;
-  background-color: var(--black);
-  color: var(--dutch-white);
+  background-color: var(--background);
+  color: var(--foreground);
   /* ensure content is never hidden behind fixed bars */
   padding-top: calc(var(--clock-bar-h) + var(--dock-gap) + var(--dock-h));
   padding-bottom: var(--footer-h);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,20 +1,18 @@
-/* global tailwind */
 /**
- * Tailwind configuration mapping custom CSS variables to theme colors.
- * This lets us use classes like `bg-plum` or `text-cambridge-blue`
- * in components while keeping the actual color values in CSS variables
- * for easy theming.
+ * Tailwind configuration mapping design tokens to semantic color roles.
  */
-tailwind.config = {
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
   theme: {
     extend: {
       colors: {
-        'dutch-white': 'var(--dutch-white)',
-        plum: 'var(--plum)',
-        'violet-jtc': 'var(--violet-jtc)',
-        black: 'var(--black)',
-        'cambridge-blue': 'var(--cambridge-blue)'
-      }
-    }
-  }
+        primary: 'var(--primary)',       // Blue Munsell
+        secondary: 'var(--secondary)',   // Paynes Gray
+        background: 'var(--background)', // Onyx
+        foreground: 'var(--foreground)', // White
+        neutral: 'var(--neutral)',       // Silver
+      },
+    },
+  },
+  plugins: [],
 }


### PR DESCRIPTION
## Summary
- replace legacy color variables with semantic design tokens
- map CSS variables to Tailwind colors for primary, secondary, background, foreground, and neutral roles
- refactor components to consume new semantic color utilities

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68990566f55883299ab57e15710791a8