### PR TITLE
Enhance layout styling and add tooltips

### DIFF
--- a/src/components/ClockBar.jsx
+++ b/src/components/ClockBar.jsx
@@ -34,20 +34,11 @@ export function ClockBar() {
   }, [])
 
   return (
-    // Slim bar fixed to the very top
-    <div className="fixed top-0 left-0 right-0 z-50 flex justify-between px-4 h-[var(--clock-bar-h)] bg-secondary/90 text-foreground font-mono text-[0.65rem] sm:text-xs">
-      {/* Left group: first two time zones */}
-      <div className="flex gap-4 items-center">
-        {times.slice(0, 2).map((tz) => (
-          <Clock key={tz.tz} city={tz.city} time={tz.time} />
-        ))}
-      </div>
-      {/* Right group: remaining time zones */}
-      <div className="flex gap-4 items-center">
-        {times.slice(2).map((tz) => (
-          <Clock key={tz.tz} city={tz.city} time={tz.time} />
-        ))}
-      </div>
+    // Floating pill slightly below the top edge
+    <div className="fixed top-2 left-1/2 -translate-x-1/2 z-50 flex gap-6 px-4 py-1 rounded-full bg-secondary/90 text-foreground font-mono text-[0.65rem] sm:text-xs shadow-lg">
+      {times.map((tz) => (
+        <Clock key={tz.tz} city={tz.city} time={tz.time} />
+      ))}
     </div>
   )
 }

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -6,7 +6,7 @@ export function Education() {
   return (
     <section
       id="education"
-      className="max-w-3xl mx-auto my-8 p-6 bg-secondary text-foreground rounded-lg shadow"
+      className="max-w-3xl mx-auto my-8 p-6 bg-secondary text-foreground rounded-lg shadow border border-neutral"
     >
       <h2 className="text-2xl font-bold mb-4 text-center text-primary">
         {t('education.title')}

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -9,17 +9,29 @@ export function Experience() {
       <div className="relative pl-10">
         {/* Vertical timeline line */}
         <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-primary to-secondary" />
-        <div className="relative mb-8 p-6 bg-secondary text-foreground rounded-xl shadow">
+        <div className="relative mb-8 p-6 bg-secondary text-foreground rounded-xl shadow border border-neutral">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <img
-                src="https://media.licdn.com/dms/image/v2/C560BAQFz7AGAFLXN0A/company-logo_200_200/company-logo_200_200/0/1641580116422/reyes_holdings_logo?e=1757548800&v=beta&t=vwhRKm6AbE3K57Ehi5kVfCkeGYdDMh8RSut0N0lx9nM"
+                src="/reyes-holdings-logo.svg"
                 alt="Reyes Holdings Logo"
                 className="w-12 h-12 object-contain"
               />
               <h3 className="text-xl font-semibold">{t('experience.role')}</h3>
             </div>
             <span className="text-sm text-neutral">{t('experience.date')}</span>
+          </div>
+          <div className="flex gap-4 mb-4">
+            <img
+              src="https://cdn.brandfetch.io/idmJWF3N06/w/400/h/400/theme/dark/icon.jpeg?c=1bxid64Mup7aczewSAYMX&t=1721803173482"
+              alt="Anthropic Logo"
+              className="w-8 h-8 object-contain"
+            />
+            <img
+              src="https://cdn.brandfetch.io/idR3duQxYl/w/800/h/800/theme/dark/symbol.png?c=1bxid64Mup7aczewSAYMX&t=1749527471692"
+              alt="OpenAI Logo"
+              className="w-8 h-8 object-contain"
+            />
           </div>
           <ul className="list-disc pl-5 space-y-2">
             {t('experience.bullets').map((item, idx) => (

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -37,7 +37,7 @@ export function Footer() {
 
   return (
     // Fixed footer anchored to bottom; padding is handled by global CSS
-    <footer className="fixed bottom-0 left-0 right-0 z-30 h-[var(--footer-h)] bg-secondary/90 text-foreground flex items-center justify-center gap-6 text-sm">
+    <footer className="fixed bottom-0 left-0 right-0 w-full z-30 h-[var(--footer-h)] bg-secondary/90 text-foreground flex items-center justify-center gap-6 text-sm">
       <SocialLink href="https://github.com/Mpawlowski5467" label={t('about.github')}>
         {gh}
       </SocialLink>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -33,7 +33,7 @@ export function Navbar() {
   return (
     // Floating container centered at top, below the clock bar
     <div
-      className="fixed top-[calc(var(--clock-bar-h)+var(--dock-gap))] left-1/2 -translate-x-1/2 z-40"
+      className="fixed top-[calc(var(--clock-bar-h)+var(--dock-gap)+0.5rem)] left-1/2 -translate-x-1/2 z-40"
       onMouseMove={handleMove}
       onMouseLeave={handleLeave}
     >
@@ -46,11 +46,10 @@ export function Navbar() {
             key={item.href}
             ref={(el) => (iconRefs.current[i] = el)}
             href={item.href}
-            title={item.label}
             aria-label={item.label}
             // Scale via inline style so neighbours react to cursor proximity
             style={{ transform: `scale(${scaleFor(i)})` }}
-            className="w-8 h-8 flex items-center justify-center text-2xl transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 ring-primary rounded-md"
+            className="group relative w-8 h-8 flex items-center justify-center text-2xl transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 ring-primary rounded-md"
             onFocus={(e) => {
               const rect = e.currentTarget.getBoundingClientRect()
               setMouseX(rect.left + rect.width / 2)
@@ -59,6 +58,9 @@ export function Navbar() {
           >
             <span role="img" aria-hidden="true">
               {item.icon}
+            </span>
+            <span className="pointer-events-none absolute bottom-full mb-2 whitespace-nowrap px-2 py-1 rounded bg-secondary text-foreground text-xs opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100">
+              {item.label}
             </span>
           </a>
         ))}

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -13,19 +13,19 @@ export function Projects() {
           <div
             key={idx}
             tabIndex="0"
-            className="p-4 rounded-lg bg-background text-foreground border border-neutral shadow"
+            className="p-4 rounded-lg bg-background text-foreground border border-neutral shadow transition-transform transform hover:-translate-y-1 focus:-translate-y-1"
           >
             {proj.link && (
               <a
                 href={proj.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-sm text-secondary underline focus:outline-none focus-visible:ring-2 ring-primary rounded"
+                className="inline-block mb-2 px-2 py-1 text-sm bg-primary text-foreground rounded no-underline hover:bg-primary/80 focus:outline-none focus-visible:ring-2 ring-primary"
               >
                 {t('projects.github')}
               </a>
             )}
-            <h3 className="text-xl font-semibold mt-2">{proj.name}</h3>
+            <h3 className="text-xl font-semibold">{proj.name}</h3>
             <p className="mt-1 text-sm leading-relaxed">{proj.desc}</p>
           </div>
         ))}

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -25,8 +25,14 @@ const databases = [
 
 const platforms = [
   { name: 'OneReach.ai', emoji: '⚙️' },
-  { name: 'OpenAI', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/openai/openai-original.svg' },
-  { name: 'Anthropic Claude', emoji: '🤖' },
+  {
+    name: 'OpenAI',
+    icon: 'https://cdn.brandfetch.io/idR3duQxYl/w/800/h/800/theme/dark/symbol.png?c=1bxid64Mup7aczewSAYMX&t=1749527471692'
+  },
+  {
+    name: 'Anthropic Claude',
+    icon: 'https://cdn.brandfetch.io/idmJWF3N06/w/400/h/400/theme/dark/icon.jpeg?c=1bxid64Mup7aczewSAYMX&t=1721803173482'
+  },
   { name: 'Google Gemini', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/google/google-original.svg' },
   { name: 'Postman', icon: 'https://cdn.jsdelivr.net/gh/devicons/devicon/icons/postman/postman-original.svg' }
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -37,7 +37,7 @@ body {
   background-color: var(--background);
   color: var(--foreground);
   /* ensure content is never hidden behind fixed bars */
-  padding-top: calc(var(--clock-bar-h) + var(--dock-gap) + var(--dock-h));
+  padding-top: calc(var(--clock-bar-h) + var(--dock-gap) + var(--dock-h) + 0.5rem);
   padding-bottom: var(--footer-h);
 }
 


### PR DESCRIPTION
## Summary
- Float timezone bar away from top edge and adjust spacing
- Add hover tooltips to navbar icons and style project GitHub buttons
- Show Anthropic and OpenAI logos in experience and update skills icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68990a9c42908329aabbb59b3b8a45a3