### PR TITLE
feat: apply semantic theme and UI refinements

### DIFF
--- a/src/components/BackToTopButton.jsx
+++ b/src/components/BackToTopButton.jsx
@@ -20,7 +20,7 @@ export function BackToTopButton() {
 
   return (
     <button
-      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-primary text-foreground border-2 border-neutral shadow-lg flex items-center justify-center hover:bg-secondary hover:text-foreground transition focus:outline-none focus-visible:ring-2 ring-primary"
+      className="fixed bottom-6 right-6 w-12 h-12 rounded-full bg-primary text-foreground border-2 border-neutral shadow-lg flex items-center justify-center hover:bg-secondary hover:text-foreground motion-safe:transition focus:outline-none focus-visible:ring-2 ring-primary"
       onClick={scrollToTop}
       aria-label="Back to top"
     >

--- a/src/components/ClockBar.jsx
+++ b/src/components/ClockBar.jsx
@@ -34,8 +34,8 @@ export function ClockBar() {
   }, [])
 
   return (
-    // Slim bar fixed to the very top
-    <div className="fixed top-0 left-0 right-0 z-50 flex justify-between px-4 h-[var(--clock-bar-h)] bg-secondary/90 text-foreground font-mono text-[0.65rem] sm:text-xs">
+    // Slim bar fixed near the top with floating style
+    <div className="fixed top-2 left-0 right-0 z-50 mx-4 flex justify-between px-4 h-[var(--clock-bar-h)] bg-secondary/80 backdrop-blur-sm rounded-lg text-foreground font-mono text-[0.65rem] sm:text-xs">
       {/* Left group: first two time zones */}
       <div className="flex gap-4 items-center">
         {times.slice(0, 2).map((tz) => (

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -6,7 +6,7 @@ export function Education() {
   return (
     <section
       id="education"
-      className="max-w-3xl mx-auto my-8 p-6 bg-secondary text-foreground rounded-lg shadow"
+      className="max-w-3xl mx-auto my-8 p-6 bg-secondary text-foreground rounded-lg border-2 border-neutral shadow"
     >
       <h2 className="text-2xl font-bold mb-4 text-center text-primary">
         {t('education.title')}

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -9,11 +9,11 @@ export function Experience() {
       <div className="relative pl-10">
         {/* Vertical timeline line */}
         <div className="absolute left-4 top-0 bottom-0 w-1 bg-gradient-to-b from-primary to-secondary" />
-        <div className="relative mb-8 p-6 bg-secondary text-foreground rounded-xl shadow">
+        <div className="relative mb-8 p-6 bg-secondary text-foreground rounded-lg border-2 border-neutral shadow">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center space-x-3">
               <img
-                src="https://media.licdn.com/dms/image/v2/C560BAQFz7AGAFLXN0A/company-logo_200_200/company-logo_200_200/0/1641580116422/reyes_holdings_logo?e=1757548800&v=beta&t=vwhRKm6AbE3K57Ehi5kVfCkeGYdDMh8RSut0N0lx9nM"
+                src="https://cdn.brandfetch.io/idmJWF3N06/w/400/h/400/theme/dark/icon.jpeg?c=1bxid64Mup7aczewSAYMX&t=1721803173482"
                 alt="Reyes Holdings Logo"
                 className="w-12 h-12 object-contain"
               />

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -7,7 +7,7 @@ function SocialLink({ href, label, children }) {
       href={href}
       aria-label={label}
       title={label}
-      className="w-6 h-6 flex items-center justify-center hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 ring-primary rounded"
+      className="w-6 h-6 flex items-center justify-center no-underline motion-safe:hover:scale-110 motion-safe:transition-transform focus:outline-none focus-visible:ring-2 ring-primary rounded"
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -37,7 +37,7 @@ export function Footer() {
 
   return (
     // Fixed footer anchored to bottom; padding is handled by global CSS
-    <footer className="fixed bottom-0 left-0 right-0 z-30 h-[var(--footer-h)] bg-secondary/90 text-foreground flex items-center justify-center gap-6 text-sm">
+    <footer className="fixed bottom-0 left-0 right-0 z-30 h-[var(--footer-h)] bg-secondary text-foreground flex items-center justify-center gap-6 text-sm">
       <SocialLink href="https://github.com/Mpawlowski5467" label={t('about.github')}>
         {gh}
       </SocialLink>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -11,13 +11,21 @@ const items = [
 export function Navbar() {
   const iconRefs = useRef([])
   const [mouseX, setMouseX] = useState(null)
+  const reduceMotion =
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
 
   // Track mouse position to scale icons based on proximity
-  const handleMove = (e) => setMouseX(e.clientX)
+  const handleMove = (e) => {
+    if (reduceMotion) return
+    setMouseX(e.clientX)
+  }
   const handleLeave = () => setMouseX(null)
 
   // Compute scale for a given icon index using distance from cursor
   const scaleFor = (idx) => {
+    if (reduceMotion) return 1
     const el = iconRefs.current[idx]
     if (!el || mouseX === null) return 1
     const rect = el.getBoundingClientRect()
@@ -42,25 +50,31 @@ export function Navbar() {
         className="flex gap-4 rounded-3xl bg-foreground/40 backdrop-blur-md shadow-lg border border-white/20 px-4 py-2"
       >
         {items.map((item, i) => (
-          <a
-            key={item.href}
-            ref={(el) => (iconRefs.current[i] = el)}
-            href={item.href}
-            title={item.label}
-            aria-label={item.label}
-            // Scale via inline style so neighbours react to cursor proximity
-            style={{ transform: `scale(${scaleFor(i)})` }}
-            className="w-8 h-8 flex items-center justify-center text-2xl transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 ring-primary rounded-md"
-            onFocus={(e) => {
-              const rect = e.currentTarget.getBoundingClientRect()
-              setMouseX(rect.left + rect.width / 2)
-            }}
-            onBlur={handleLeave}
-          >
-            <span role="img" aria-hidden="true">
-              {item.icon}
+          <div key={item.href} className="relative group">
+            <a
+              ref={(el) => (iconRefs.current[i] = el)}
+              href={item.href}
+              title={item.label}
+              aria-label={item.label}
+              // Scale via inline style so neighbours react to cursor proximity
+              style={{ transform: `scale(${scaleFor(i)})` }}
+              className="w-8 h-8 flex items-center justify-center text-2xl no-underline motion-safe:transition-transform duration-150 ease-out focus:outline-none focus-visible:ring-2 ring-primary rounded-md"
+              onFocus={(e) => {
+                const rect = e.currentTarget.getBoundingClientRect()
+                setMouseX(rect.left + rect.width / 2)
+              }}
+              onBlur={handleLeave}
+            >
+              <span role="img" aria-hidden="true">
+                {item.icon}
+              </span>
+            </a>
+            <span
+              className="pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 rounded bg-neutral text-background text-xs shadow-lg opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
+            >
+              {item.label}
             </span>
-          </a>
+          </div>
         ))}
       </nav>
     </div>

--- a/src/components/PersonalInfo.jsx
+++ b/src/components/PersonalInfo.jsx
@@ -7,7 +7,7 @@ function IconLink({ href, label, children }) {
       href={href}
       aria-label={label}
       title={label}
-      className="w-8 h-8 flex items-center justify-center rounded hover:scale-110 transition-transform focus:outline-none focus-visible:ring-2 ring-primary"
+      className="w-8 h-8 flex items-center justify-center rounded no-underline motion-safe:hover:scale-110 motion-safe:transition-transform focus:outline-none focus-visible:ring-2 ring-primary"
       target="_blank"
       rel="noopener noreferrer"
     >

--- a/src/components/Projects.jsx
+++ b/src/components/Projects.jsx
@@ -13,14 +13,14 @@ export function Projects() {
           <div
             key={idx}
             tabIndex="0"
-            className="p-4 rounded-lg bg-background text-foreground border border-neutral shadow"
+            className="p-4 rounded-lg bg-background text-foreground border border-neutral shadow motion-safe:hover:-translate-y-1 motion-safe:transition-transform"
           >
             {proj.link && (
               <a
                 href={proj.link}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-sm text-secondary underline focus:outline-none focus-visible:ring-2 ring-primary rounded"
+                className="inline-block no-underline bg-primary text-foreground rounded px-3 py-1 motion-safe:transition-colors hover:bg-secondary focus:outline-none focus-visible:ring-2 ring-primary"
               >
                 {t('projects.github')}
               </a>

--- a/src/index.css
+++ b/src/index.css
@@ -45,5 +45,6 @@ body {
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     transition: none !important;
+    animation: none !important;
   }
 }


### PR DESCRIPTION
## Summary
- float the timezone bar and macOS-style dock while using semantic Tailwind theme tokens
- style project, education, and experience cards with neutral borders and hover motion
- add accessible tooltips and motion-safe transitions across UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68990ef40c00832980e6e8bbe172adf3